### PR TITLE
travis.yml - rvm version bumps + add rvm 2.3.0

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -3,14 +3,17 @@
   includes:
   - rvm: 1.9.3
     env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
-  - rvm: 2.1.7
+  - rvm: 2.1.8
     env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
-  - rvm: 2.1.7
+  - rvm: 2.1.8
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
-  - rvm: 2.2.3
+  - rvm: 2.2.4
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
-  - rvm: 2.2.3
+  - rvm: 2.2.4
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=rubocop
+  allow_failures:
+  - rvm: 2.3.0
+    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
 Gemfile:
   required:
     ':test':


### PR DESCRIPTION
Bump rvm minor versions for 2.1.x and 2.2.x
Add rvm 2.3.0 to matrix, but allow failures