### PR TITLE
Removes deprecated argument

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ Metrics/LineLength:
   Max: 120
 
 # dealbreaker:
-Style/TrailingComma:
+Style/TrailingCommaInArguments:
   Enabled: false
 
 # we still support ruby 1.8


### PR DESCRIPTION
Fixes 
```
Error: The `Style/TrailingComma` cop no longer exists. Please use `Style/TrailingCommaInLiteral` and/or `Style/TrailingCommaInArguments` instead.
```