### PR TITLE
Add Ruby 2.3.0 to matrix

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -11,9 +11,10 @@
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
   - rvm: 2.2.4
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=rubocop
-  allow_failures:
   - rvm: 2.3.0
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
+  allow_failures:
+  - rvm: 2.3.0
 Gemfile:
   required:
     ':test':


### PR DESCRIPTION
PR #60 added allow_failures of 2.3.0 but did not actually add it to the matrix