### PR TITLE
Add env for Travis allow_failures

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -15,6 +15,7 @@
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
   allow_failures:
   - rvm: 2.3.0
+    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
 Gemfile:
   required:
     ':test':


### PR DESCRIPTION
Modulesync expects env for the allow_failures section, so give it one