### PR TITLE
Pin rubocop to version 0.37.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ source "https://rubygems.org"
 
 group :test do
   gem 'rake'
-  gem 'rubocop', '0.35.0'
+  gem 'rubocop', '0.37.0'
 end
 
 group :development do


### PR DESCRIPTION
This should solve the error message ```unrecognized cop Style/TrailingCommaInArguments``` of issue #74.