### PR TITLE
Adding more Puppet versions in travis tests

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -10,6 +10,10 @@
   - rvm: 2.1.8
     env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test FUTURE_PARSER=yes
   - rvm: 2.1.8
+    env: PUPPET_VERSION="~> 3.5" STRICT_VARIABLES="yes" CHECK=test FUTURE_PARSER=yes
+  - rvm: 2.1.8
+    env: PUPPET_VERSION="~> 3.8" STRICT_VARIABLES="yes" CHECK=test FUTURE_PARSER=yes
+  - rvm: 2.1.8
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
   - rvm: 2.2.4
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test


### PR DESCRIPTION
Hi,

There have been significant changes in several versions of Puppet 3.
It's a good practice to test the different versions.

For example, when I build a dependent package with Travis on puppet 3.5 to 3.8 I sometimes get facts that disappeared from the standard.

If you could just tell me if you'd be ok to add those environments to the travis builds, it would be awesome.

Thanks! :)
Joseph