### PR TITLE
Adds rspec-puppet-facts to default

### DIFF
--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet-facts'
+include RspecPuppetFacts
 <%- [@configs['spec_overrides']].flatten.compact.each do |line| -%>
  <%= line %>
 <%- end -%>


### PR DESCRIPTION
We include the gem, makes sense to add it to the spec_helper