### PR TITLE
Disable fail on trailing comma in literal

### DIFF
--- a/moduleroot/.rubocop.yml
+++ b/moduleroot/.rubocop.yml
@@ -38,6 +38,8 @@ Metrics/ClassLength:
 # dealbreaker:
 Style/TrailingCommaInArguments:
   Enabled: false
+Style/TrailingCommaInLiteral:
+  Enabled: false
 Style/ClosingParenthesisIndentation:
   Enabled: false
 


### PR DESCRIPTION
Kinda makes sense to keep it in-line with comma in literals, and we already have the puppet trailing comma lint enabled?