### PR TITLE
Improved conditional release

### DIFF
--- a/moduleroot/.travis.yml
+++ b/moduleroot/.travis.yml
@@ -57,3 +57,4 @@ deploy:
     all_branches: true
     # Only publish if our main Ruby target builds
     rvm: 1.9.3
+    condition: "$FUTURE_PARSER = yes"


### PR DESCRIPTION
There are two builds on rvm 1.9.3. One will pass tests, upload to the forge, and result in a success. The other will pass tests, try to upload to the forge and find the release already exists, and result in a failure. To prevent this, add a condition to match only one of the two 1.9.3 builds.