### PR TITLE
Pin rake version to avoid rubocop/rake 11 incompatibility

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -24,6 +24,7 @@ Gemfile:
   required:
     ':test':
       - gem: rake
+        version: '< 11'
       - gem: rspec-puppet
         git: https://github.com/rodjek/rspec-puppet.git
       - gem: puppet-lint


### PR DESCRIPTION
All tests are failing with:

https://travis-ci.org/voxpupuli/puppet-corosync/jobs/114738369

```
$ bundle exec rake $CHECK
rake aborted!
NoMethodError: undefined method `last_comment' for #<Rake::Application:0x000000021df220>
/home/travis/build/voxpupuli/puppet-corosync/vendor/bundle/ruby/2.2.0/gems/rubocop-0.37.2/lib/rubocop/rake_task.rb:24:in `initialize'
/home/travis/build/voxpupuli/puppet-corosync/Rakefile:9:in `new'
/home/travis/build/voxpupuli/puppet-corosync/Rakefile:9:in `<top (required)>'
(See full trace by running task with --trace)
```

Once bbatsov/rubocop#2931 is released then rubocop can be updated and
the pinning removed.

Thanks to https://github.com/theforeman/foreman/pull/3298 for the pointer