### PR TITLE
Change character width to 140

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -58,7 +58,7 @@ Gemfile:
 Rakefile:
   default_disabled_lint_checks:
   - 'relative'
-  - 'disable_80chars'
+  - 'disable_140chars'
   - 'disable_class_inherits_from_params_class'
   - 'disable_documentation'
   - 'disable_single_quote_string_with_variables'


### PR DESCRIPTION
Please merge. 

As you can see at [PR #419](https://github.com/rodjek/puppet-lint/pull/419) the character width has been changed to 140 and our [current configuration](https://github.com/voxpupuli/modulesync_config/blob/master/config_defaults.yml#L61) has no effect.