### PR TITLE
Add Gemfile/puppet_version .sync.yml option

### DIFF
--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -54,7 +54,7 @@ else
 gem 'facter', :require => false, :groups => [:test]
 end
 
-ENV['PUPPET_VERSION'].nil? ? puppetversion = '~> 3.0' : puppetversion = ENV['PUPPET_VERSION'].to_s
+ENV['PUPPET_VERSION'].nil? ? puppetversion = '<%= @configs['puppet_version'] || '~> 3.0' %>' : puppetversion = ENV['PUPPET_VERSION'].to_s
 gem 'puppet', puppetversion, :require => false, :groups => [:test]
 
 # vim:ft=ruby


### PR DESCRIPTION
There should be a way for a module to specify what version of Puppet to require in the Gemfile. This commit adds a .sync.yml variable that can be used to set this. It expects a version specifier in the same format a Gemfile would, e.g. `~> 4.0`.

Fixes #102.