### PR TITLE
Remove guard-rake

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -49,7 +49,6 @@ Gemfile:
     ':development':
       - gem: travis
       - gem: travis-lint
-      - gem: guard-rake
     ':system_tests':
       - gem: beaker
       - gem: beaker-rspec


### PR DESCRIPTION
We do not use the `guard-rake` gem. This may be useful on a developer's station while they hack on some code, but has zero benefit on Travis CI and in fact is causing conflicts as the guard organization [broke their own gem's compatibility](https://github.com/guard/listen/issues/374). I am proposing we remove this gem entirely to avoid conflicts, even if guard fixes their problem.