### PR TITLE
Allow rake target 'test' to be configured

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -62,4 +62,10 @@ Rakefile:
   - 'disable_class_inherits_from_params_class'
   - 'disable_documentation'
   - 'disable_single_quote_string_with_variables'
+  default_enabled_rake_targets:
+  - 'metadata_lint'
+  - 'lint'
+  - 'syntax'
+  - 'spec'
+
 ...

--- a/moduleroot/Rakefile
+++ b/moduleroot/Rakefile
@@ -30,10 +30,10 @@ RSpec::Core::RakeTask.new(:acceptance) do |t|
   t.pattern = 'spec/acceptance'
 end
 
-desc 'Run metadata_lint, lint, syntax, and spec tests.'
+<% targets = @configs['default_enabled_rake_targets']  - ( @configs['extra_disabled_rake_targets'] || [] ) -%>
+desc 'Run tests <%= targets.join(', ') %>'
 task test: [
-  :metadata_lint,
-  :lint,
-  :syntax,
-  :spec,
+<% targets.each do |t| -%>
+  :<%= t %>,
+<% end -%>
 ]


### PR DESCRIPTION
Currently the rake target *test*  is hardcoded to
metadata_lint, lint, syntax and spec.

This list is now configured via a
*default_enabled_rake_targets* and an optional
*extra_disabled_rake_targets* that removes rake
targets from from the *test* target.