### PR TITLE
remove rubocop from our gemlist

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -43,6 +43,7 @@ Gemfile:
       - gem: puppet-strings
         git: https://github.com/puppetlabs/puppetlabs-strings.git
       - gem: rubocop-rspec
+        version: '~> 1.4'
     ':development':
       - gem: travis
       - gem: travis-lint

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -42,8 +42,6 @@ Gemfile:
         git: https://github.com/voxpupuli/voxpupuli-release-gem.git
       - gem: puppet-strings
         git: https://github.com/puppetlabs/puppetlabs-strings.git
-      - gem: rubocop
-        version: '~> 0.39'
       - gem: rubocop-rspec
     ':development':
       - gem: travis


### PR DESCRIPTION
we have rspec-rubocop now, is has rubocop as a dependency
https://rubygems.org/gems/rubocop-rspec