### PR TITLE
Replace jruby-19mode with 1.9.3

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -1,10 +1,10 @@
 ---
 .travis.yml:
   includes:
-  - rvm: jruby-19mode
+  - rvm: 1.9.3
     env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
-  - rvm: jruby-19mode
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes" CHECK=test
   - rvm: 2.1
     env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
   - rvm: 2.1

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -4,7 +4,7 @@
   - rvm: 1.9.3
     env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
   - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes" CHECK=test
+    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes" CHECK=test
   - rvm: 2.1
     env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
   - rvm: 2.1


### PR DESCRIPTION
Rspec-puppet and jruby seem to be incompatible. When compiling catalogs, rspec-puppet attempts to enforce them to some extent. This is a problem with jruby and execs because it is unable to fork. Not only is it breaking the build, but it's not representative of reality: the jruby environment on the puppetserver only compiles the catalog, the "real" ruby environment on the agent enforces the catalog. By restoring the use of rvm 1.9.3, our build pipeline should be restored.