### PR TITLE
bump ruby to 2.3.1, don't ignore fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ build/
 ## Environment normalisation:
 /.bundle/
 /vendor
+/.vendor
 /lib/bundler/man/
 
 # for a library or gem, you might want to ignore these files since the code is

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -11,12 +11,12 @@
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
   - rvm: 2.2
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
-  - rvm: 2.3.0
+  - rvm: 2.3.1
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=rubocop
-  - rvm: 2.3.0
+  - rvm: 2.3.1
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
   allow_failures:
-  - rvm: 2.3.0
+  - rvm: 2.3.1
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
 Gemfile:
   required:

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -15,9 +15,6 @@
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=rubocop
   - rvm: 2.3.1
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
-  allow_failures:
-  - rvm: 2.3.1
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
 Gemfile:
   required:
     ':test':


### PR DESCRIPTION
Ruby 2.3.1 is getting serious in the puppet world. Puppet will migrate their AIO packages to 2.3.1 in the near future so we should take testing on that version serious.