### PR TITLE
Add .github/ templates

### DIFF
--- a/moduleroot/.github/CONTRIBUTING.md
+++ b/moduleroot/.github/CONTRIBUTING.md
@@ -93,5 +93,3 @@ If you don't want to have to recreate the virtual machine every time you
 can use `BEAKER_DESTROY=no` and `BEAKER_PROVISION=no`. On the first run you will
 at least need `BEAKER_PROVISION` set to yes (the default). The Vagrantfile
 for the created virtual machines will be in `.vagrant/beaker_vagrant_fies`.
-
-# vim: syntax=markdown

--- a/moduleroot/.github/ISSUE_TEMPLATE.md
+++ b/moduleroot/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,26 @@
+Please check the following items before submitting an issue -- thank you!
+
+Nnote that this project is released with a Contributor Code of Conduct.
+By participating in this project you agree to abide by its terms.
+[Contributor Code of Conduct](https://voxpupuli.org/coc/).
+
+- [ ] There is no existing issue or PR that addresses this problem
+
+Optional, but makes our lives much easier:
+
+- [ ] The issue affects the latest release of this module at the time of
+  submission
+
+- - -
+
+### Affected Puppet, Ruby, OS and module versions/distributions
+
+### What are you seeing
+
+### What behaviour did you expect instead
+
+### How did this behaviour get triggered
+
+### Output log
+
+### Any additional information you'd like to impart

--- a/moduleroot/.github/PULL_REQUEST_TEMPLATE.md
+++ b/moduleroot/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+Please check the following items before submitting a PR -- thank you!
+
+Note that this project is released with a Contributor Code of Conduct.
+By participating in this project you agree to abide by its terms.
+[Contributor Code of Conduct](https://voxpupuli.org/coc/).
+
+- [ ] There is no existing PR that addresses this problem
+- [ ] Mentioned any existing issues in your commit so they get linked and
+  closed once this PR gets merged, i.e: `Closes #1554` in the body of a commit
+- [ ] Followed the instructions in the [Contributing](CONTRIBUTING.md) document
+- [ ] Ran the unit/spec tests and ensured they still pass
+- [ ] Added tests to cover the new behaviour
+- [ ] Updated the documentation to match the changes
+- [ ] When possible, add an entry to the CHANGELOG file
+- [ ] Squashed your PR down to a single commit. You may forego this if the PR
+  tries to address multiple issues. Though we prefer one PR per feature/fix,
+  sometimes that's not feasible. In that case ensure that a single feature/fix
+  and associated tests and documentation is bundled up in one commit
+
+Optional, but extra points:
+
+- [ ] Added tests to ensure the old behaviour cannot accidentally be
+  reintroduced
+
+- - -
+
+<!--
+Please provide further information about your PR.
+It should contain all the necessary information for the maintainers to be
+able to understand the issue at hand and the code behind fixing it.
+
+PROVIDE THIS INFORMATION OUTSIDE OF THIS COMMENT BLOCK OR DELETE THIS BLOCK
+-->


### PR DESCRIPTION
This moves `CONTRIBUTING.md` to `.github/` and adds templates for when someone opens an issue or a PR.

The wording in all of this is obviously up for discussion, so, discuss!