### PR TITLE
don't require beaker

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -46,7 +46,6 @@ Gemfile:
       - gem: travis-lint
       - gem: guard-rake
     ':system_tests':
-      - gem: beaker
       - gem: beaker-rspec
       - gem: beaker-puppet_install_helper
         require: false


### PR DESCRIPTION
this is useless because beaker-puppet_install_helper and beaker-rspec
already require it