### PR TITLE
don't explicitly include puppet-lint

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -23,8 +23,6 @@ Gemfile:
         git: https://github.com/rodjek/rspec-puppet.git
       - gem: rspec-puppet-facts
       - gem: rspec-puppet-utils
-      - gem: puppet-lint
-        git: https://github.com/rodjek/puppet-lint.git
       - gem: puppet-lint-absolute_classname-check
       - gem: puppet-lint-leading_zero-check
       - gem: puppet-lint-trailing_comma-check


### PR DESCRIPTION
we've multiple gems as puppet-lint plugins that all requier puppet-lint