### PR TITLE
test if we can build a module

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -11,7 +11,7 @@
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
   - rvm: 2.2
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
-  - rvm: 2.2
+  - rvm: 2.3.1
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=build
   - rvm: 2.3.1
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=rubocop

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -11,6 +11,8 @@
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
   - rvm: 2.2
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
+  - rvm: 2.2
+    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=build
   - rvm: 2.3.1
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=rubocop
   - rvm: 2.3.1

--- a/moduleroot/.travis.yml
+++ b/moduleroot/.travis.yml
@@ -62,4 +62,4 @@ deploy:
     # all_branches is required to use tags
     all_branches: true
     # Only publish if our main Ruby target builds
-    rvm: 2.2
+    rvm: 2.3.1


### PR DESCRIPTION
we had some issues yesterday with the corosync module. We were unable to
build it because of a mistake in the metadata.json. We should always
ensure that a build worked. Also bumping the release ruby version to 2.3.1. We're already running tests + rubocop on that version.