### PR TITLE
rename cop to PreferredHashMethods

### DIFF
--- a/moduleroot/.rubocop.yml
+++ b/moduleroot/.rubocop.yml
@@ -263,7 +263,7 @@ Style/Documentation:
 Style/DefWithParentheses:
   Enabled: true
 
-Style/DeprecatedHashMethods:
+Style/PreferredHashMethods:
   Enabled: true
 
 Style/DotPosition:


### PR DESCRIPTION
 Rename Style/DeprecatedHashMethods to Style/PreferredHashMethods. this
 change happend in the last rubocop release
 https://github.com/bbatsov/rubocop/issues/3224