### PR TITLE
Pin rest-client gem to avoid breakage on Ruby 1.9x

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -35,6 +35,10 @@ Gemfile:
       - gem: metadata-json-lint
       - gem: puppet-blacksmith
         git: https://github.com/voxpupuli/puppet-blacksmith.git
+        # puppet-blacksmith requires rest-client, but rest-client 2.x requires
+        # Ruby 2.0 or above
+      - gem: rest-client
+        version: '~> 1.8'
       - gem: voxpupuli-release
         git: https://github.com/voxpupuli/voxpupuli-release-gem.git
       - gem: puppet-strings


### PR DESCRIPTION
The rest-client gem is required by puppet-blacksmith, but 2.x of the gem requires Ruby 2.0 or above