### PR TITLE
Fix indent for spec_overrides in spec_helper.rb

### DIFF
--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -9,7 +9,8 @@ RSpec.configure do |c|
     <%- end unless @configs['default_facts'].empty? -%>
   }
 end
+
 <%- [@configs['spec_overrides']].flatten.compact.each do |line| -%>
- <%= line %>
+<%= line %>
 <%- end -%>
 # vim: syntax=ruby


### PR DESCRIPTION
Remove the space for the spec_overrides and also add a newline to make things easier to read

Rubocop frowns upon the current inconsistent indenting