### PR TITLE
Disable Style/TrailingCommaInLiteral cop

### DIFF
--- a/moduleroot/.rubocop.yml
+++ b/moduleroot/.rubocop.yml
@@ -322,7 +322,7 @@ Style/TrailingCommaInArguments:
   Enabled: true
 
 Style/TrailingCommaInLiteral:
-  Enabled: true
+  Enabled: false
 
 Style/GlobalVars:
   Enabled: true


### PR DESCRIPTION
The spec_overrides code in spec_helper.rb always puts a comma on each line.