### PR TITLE
bump version on HEAD

### DIFF
--- a/moduleroot/.msync.yml
+++ b/moduleroot/.msync.yml
@@ -1,1 +1,1 @@
-modulesync_config_version: '0.9.1'
+modulesync_config_version: '0.9.2'


### PR DESCRIPTION
we tagged 0.9.1 here so we should move HEAD forwards to the next release.