### PR TITLE
fix rubocop-rspec

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -41,7 +41,7 @@ Gemfile:
       - gem: rubocop-rspec
         version: '~> 1.5'
         ruby-operator: '>='
-        ruby-version: '2.0.0'
+        ruby-version: '2.3.0'
       - gem: json_pure
         version: '<= 2.0.1'
         ruby-operator: '<'

--- a/moduleroot/Rakefile
+++ b/moduleroot/Rakefile
@@ -3,7 +3,7 @@ require 'puppet_blacksmith/rake_tasks'
 require 'voxpupuli/release/rake_tasks'
 require 'puppet-strings/rake_tasks'
 
-if RUBY_VERSION >= '2.0.0'
+if RUBY_VERSION >= '2.3.0'
   require 'rubocop/rake_task'
 
   RuboCop::RakeTask.new(:rubocop) do |task|


### PR DESCRIPTION
rubocop-rspec dropped support for ruby2 and ruby21 here:
https://github.com/nevir/rubocop-rspec/commit/8a68286c31afef6a777b5b4dc65a32889df881d4

This got today released as version 1.5.2.

This commit only installs rubocop-rspec if we're on ruby2.3 or newer. We
tested it successfully here:
https://github.com/voxpupuli/puppet-community_kickstarts/pull/15
https://travis-ci.org/voxpupuli/puppet-community_kickstarts/builds/148977207