### PR TITLE
read default_module_facts.yml if it exists

### DIFF
--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -8,7 +8,7 @@ RSpec.configure do |c|
     facterversion: Facter.version
   }
   default_facts += YAML.read_file('default_facts.yml') if File.exist?('default_facts.yml')
-  default_facts += YAML.read_file('default_facts.yml') if File.exist?('default_module_facts.yml')
+  default_facts += YAML.read_file('default_module_facts.yml') if File.exist?('default_module_facts.yml')
   c.default_facts = default_facts
 end
 


### PR DESCRIPTION
Currently it's reading `default_facts.yml` twice if `default_module_facts.yml` exists.