### PR TITLE
make loading default facts more robust

### DIFF
--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -7,8 +7,8 @@ RSpec.configure do |c|
     puppetversion: Puppet.version,
     facterversion: Facter.version
   }
-  default_facts += YAML.read_file('default_facts.yml') if File.exist?('default_facts.yml')
-  default_facts += YAML.read_file('default_module_facts.yml') if File.exist?('default_module_facts.yml')
+  default_facts.merge!(YAML.load(File.read(File.expand_path('../default_facts.yml', __FILE__)))) if File.exist?(File.expand_path('../default_facts.yml', __FILE__))
+  default_facts.merge!(YAML.load(File.read(File.expand_path('../default_module_facts.yml', __FILE__)))) if File.exist?(File.expand_path('../default_module_facts.yml', __FILE__))
   c.default_facts = default_facts
 end
 


### PR DESCRIPTION
* Merge instead of attempting to append - means default_module_facts can override default_facts
* Make the loading of the files independent of the current working directory
* YAML.read_file doesn't appear to be a valid method - replaced with YAML.load

Tested on Ruby 1.9.3, 2.1, 2.2 and 2.3.1. See results at https://travis-ci.org/jfryman/puppet-nginx/builds/150137623, which tested this commit: https://github.com/jfryman/puppet-nginx/commit/c529a148e5e6436c578fd52527f179ddfdc5fa01