### PR TITLE
Ruby2.4 support + minor fix

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -17,6 +17,10 @@
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=rubocop
   - rvm: 2.3.1
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
+  - rvm: 2.4.0-preview1
+    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
+  allow_failures:
+    - rvm: 2.4.0-preview1
 Gemfile:
   required:
     ':test':

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -43,7 +43,7 @@ Gemfile:
       - gem: puppet-strings
         git: https://github.com/puppetlabs/puppetlabs-strings.git
       - gem: rubocop-rspec
-        version: '~> 1.5'
+        version: '~> 1.6'
         ruby-operator: '>='
         ruby-version: '2.3.0'
       - gem: json_pure

--- a/moduleroot/.rubocop.yml
+++ b/moduleroot/.rubocop.yml
@@ -14,476 +14,476 @@ AllCops:
     <%- end -%>
     <%- end -%>
 Lint/ConditionPosition:
-  Enabled: true
+  Enabled: True
 
 Lint/ElseLayout:
-  Enabled: true
+  Enabled: True
 
 Lint/UnreachableCode:
-  Enabled: true
+  Enabled: True
 
 Lint/UselessComparison:
-  Enabled: true
+  Enabled: True
 
 Lint/EnsureReturn:
-  Enabled: true
+  Enabled: True
 
 Lint/HandleExceptions:
-  Enabled: true
+  Enabled: True
 
 Lint/LiteralInCondition:
-  Enabled: true
+  Enabled: True
 
 Lint/ShadowingOuterLocalVariable:
-  Enabled: true
+  Enabled: True
 
 Lint/LiteralInInterpolation:
-  Enabled: true
+  Enabled: True
 
 Style/HashSyntax:
-  Enabled: true
+  Enabled: True
 
 Style/RedundantReturn:
-  Enabled: true
+  Enabled: True
 
 Lint/AmbiguousOperator:
-  Enabled: true
+  Enabled: True
 
 Lint/AssignmentInCondition:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceBeforeComment:
-  Enabled: true
+  Enabled: True
 
 Style/AndOr:
-  Enabled: true
+  Enabled: True
 
 Style/RedundantSelf:
-  Enabled: true
+  Enabled: True
 
 # Method length is not necessarily an indicator of code quality
 Metrics/MethodLength:
-  Enabled: false
+  Enabled: False
 
 # Module length is not necessarily an indicator of code quality
 Metrics/ModuleLength:
-  Enabled: false
+  Enabled: False
 
 Style/WhileUntilModifier:
-  Enabled: true
+  Enabled: True
 
 Lint/AmbiguousRegexpLiteral:
-  Enabled: true
+  Enabled: True
 
 Lint/Eval:
-  Enabled: true
+  Enabled: True
 
 Lint/BlockAlignment:
-  Enabled: true
+  Enabled: True
 
 Lint/DefEndAlignment:
-  Enabled: true
+  Enabled: True
 
 Lint/EndAlignment:
-  Enabled: true
+  Enabled: True
 
 Lint/DeprecatedClassMethods:
-  Enabled: true
+  Enabled: True
 
 Lint/Loop:
-  Enabled: true
+  Enabled: True
 
 Lint/ParenthesesAsGroupedExpression:
-  Enabled: true
+  Enabled: True
 
 Lint/RescueException:
-  Enabled: true
+  Enabled: True
 
 Lint/StringConversionInInterpolation:
-  Enabled: true
+  Enabled: True
 
 Lint/UnusedBlockArgument:
-  Enabled: true
+  Enabled: True
 
 Lint/UnusedMethodArgument:
-  Enabled: true
+  Enabled: True
 
 Lint/UselessAccessModifier:
-  Enabled: true
+  Enabled: True
 
 Lint/UselessAssignment:
-  Enabled: true
+  Enabled: True
 
 Lint/Void:
-  Enabled: true
+  Enabled: True
 
 Style/AccessModifierIndentation:
-  Enabled: true
+  Enabled: True
 
 Style/AccessorMethodName:
-  Enabled: true
+  Enabled: True
 
 Style/Alias:
-  Enabled: true
+  Enabled: True
 
 Style/AlignArray:
-  Enabled: true
+  Enabled: True
 
 Style/AlignHash:
-  Enabled: true
+  Enabled: True
 
 Style/AlignParameters:
-  Enabled: true
+  Enabled: True
 
 Metrics/BlockNesting:
-  Enabled: true
+  Enabled: True
 
 Style/AsciiComments:
-  Enabled: true
+  Enabled: True
 
 Style/Attr:
-  Enabled: true
+  Enabled: True
 
 Style/BracesAroundHashParameters:
-  Enabled: true
+  Enabled: True
 
 Style/CaseEquality:
-  Enabled: true
+  Enabled: True
 
 Style/CaseIndentation:
-  Enabled: true
+  Enabled: True
 
 Style/CharacterLiteral:
-  Enabled: true
+  Enabled: True
 
 Style/ClassAndModuleCamelCase:
-  Enabled: true
+  Enabled: True
 
 Style/ClassAndModuleChildren:
-  Enabled: false
+  Enabled: False
 
 Style/ClassCheck:
-  Enabled: true
+  Enabled: True
 
 # Class length is not necessarily an indicator of code quality
 Metrics/ClassLength:
-  Enabled: false
+  Enabled: False
 
 Style/ClassMethods:
-  Enabled: true
+  Enabled: True
 
 Style/ClassVars:
-  Enabled: true
+  Enabled: True
 
 Style/WhenThen:
-  Enabled: true
+  Enabled: True
 
 Style/WordArray:
-  Enabled: true
+  Enabled: True
 
 Style/UnneededPercentQ:
-  Enabled: true
+  Enabled: True
 
 Style/Tab:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceBeforeSemicolon:
-  Enabled: true
+  Enabled: True
 
 Style/TrailingBlankLines:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceInsideBlockBraces:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceInsideBrackets:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceInsideHashLiteralBraces:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceInsideParens:
-  Enabled: true
+  Enabled: True
 
 Style/LeadingCommentSpace:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceBeforeFirstArg:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceAfterColon:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceAfterComma:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceAfterMethodName:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceAfterNot:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceAfterSemicolon:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceAroundEqualsInParameterDefault:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceAroundOperators:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceBeforeBlockBraces:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceBeforeComma:
-  Enabled: true
+  Enabled: True
 
 Style/CollectionMethods:
-  Enabled: true
+  Enabled: True
 
 Style/CommentIndentation:
-  Enabled: true
+  Enabled: True
 
 Style/ColonMethodCall:
-  Enabled: true
+  Enabled: True
 
 Style/CommentAnnotation:
-  Enabled: true
+  Enabled: True
 
 # 'Complexity' is very relative
 Metrics/CyclomaticComplexity:
-  Enabled: false
+  Enabled: False
 
 Style/ConstantName:
-  Enabled: true
+  Enabled: True
 
 Style/Documentation:
-  Enabled: false
+  Enabled: False
 
 Style/DefWithParentheses:
-  Enabled: true
+  Enabled: True
 
 Style/PreferredHashMethods:
-  Enabled: true
+  Enabled: True
 
 Style/DotPosition:
   EnforcedStyle: trailing
 
 Style/DoubleNegation:
-  Enabled: true
+  Enabled: True
 
 Style/EachWithObject:
-  Enabled: true
+  Enabled: True
 
 Style/EmptyLineBetweenDefs:
-  Enabled: true
+  Enabled: True
 
 Style/IndentArray:
-  Enabled: true
+  Enabled: True
 
 Style/IndentHash:
-  Enabled: true
+  Enabled: True
 
 Style/IndentationConsistency:
-  Enabled: true
+  Enabled: True
 
 Style/IndentationWidth:
-  Enabled: true
+  Enabled: True
 
 Style/EmptyLines:
-  Enabled: true
+  Enabled: True
 
 Style/EmptyLinesAroundAccessModifier:
-  Enabled: true
+  Enabled: True
 
 Style/EmptyLiteral:
-  Enabled: true
+  Enabled: True
 
 # Configuration parameters: AllowURI, URISchemes.
 Metrics/LineLength:
-  Enabled: false
+  Enabled: False
 
 Style/MethodCallParentheses:
-  Enabled: true
+  Enabled: True
 
 Style/MethodDefParentheses:
-  Enabled: true
+  Enabled: True
 
 Style/LineEndConcatenation:
-  Enabled: true
+  Enabled: True
 
 Style/TrailingWhitespace:
-  Enabled: true
+  Enabled: True
 
 Style/StringLiterals:
-  Enabled: true
+  Enabled: True
 
 Style/TrailingCommaInArguments:
-  Enabled: true
+  Enabled: True
 
 Style/TrailingCommaInLiteral:
-  Enabled: true
+  Enabled: True
 
 Style/GlobalVars:
-  Enabled: true
+  Enabled: True
 
 Style/GuardClause:
-  Enabled: true
+  Enabled: True
 
 Style/IfUnlessModifier:
-  Enabled: true
+  Enabled: True
 
 Style/MultilineIfThen:
-  Enabled: true
+  Enabled: True
 
 Style/NegatedIf:
-  Enabled: true
+  Enabled: True
 
 Style/NegatedWhile:
-  Enabled: true
+  Enabled: True
 
 Style/Next:
-  Enabled: true
+  Enabled: True
 
 Style/SingleLineBlockParams:
-  Enabled: true
+  Enabled: True
 
 Style/SingleLineMethods:
-  Enabled: true
+  Enabled: True
 
 Style/SpecialGlobalVars:
-  Enabled: true
+  Enabled: True
 
 Style/TrivialAccessors:
-  Enabled: true
+  Enabled: True
 
 Style/UnlessElse:
-  Enabled: true
+  Enabled: True
 
 Style/VariableInterpolation:
-  Enabled: true
+  Enabled: True
 
 Style/VariableName:
-  Enabled: true
+  Enabled: True
 
 Style/WhileUntilDo:
-  Enabled: true
+  Enabled: True
 
 Style/EvenOdd:
-  Enabled: true
+  Enabled: True
 
 Style/FileName:
-  Enabled: true
+  Enabled: True
 
 Style/For:
-  Enabled: true
+  Enabled: True
 
 Style/Lambda:
-  Enabled: true
+  Enabled: True
 
 Style/MethodName:
-  Enabled: true
+  Enabled: True
 
 Style/MultilineTernaryOperator:
-  Enabled: true
+  Enabled: True
 
 Style/NestedTernaryOperator:
-  Enabled: true
+  Enabled: True
 
 Style/NilComparison:
-  Enabled: true
+  Enabled: True
 
 Style/FormatString:
-  Enabled: true
+  Enabled: True
 
 Style/MultilineBlockChain:
-  Enabled: true
+  Enabled: True
 
 Style/Semicolon:
-  Enabled: true
+  Enabled: True
 
 Style/SignalException:
-  Enabled: true
+  Enabled: True
 
 Style/NonNilCheck:
-  Enabled: true
+  Enabled: True
 
 Style/Not:
-  Enabled: true
+  Enabled: True
 
 Style/NumericLiterals:
-  Enabled: true
+  Enabled: True
 
 Style/OneLineConditional:
-  Enabled: true
+  Enabled: True
 
 Style/OpMethod:
-  Enabled: true
+  Enabled: True
 
 Style/ParenthesesAroundCondition:
-  Enabled: true
+  Enabled: True
 
 Style/PercentLiteralDelimiters:
-  Enabled: true
+  Enabled: True
 
 Style/PerlBackrefs:
-  Enabled: true
+  Enabled: True
 
 Style/PredicateName:
-  Enabled: true
+  Enabled: True
 
 Style/RedundantException:
-  Enabled: true
+  Enabled: True
 
 Style/SelfAssignment:
-  Enabled: true
+  Enabled: True
 
 Style/Proc:
-  Enabled: true
+  Enabled: True
 
 Style/RaiseArgs:
-  Enabled: true
+  Enabled: True
 
 Style/RedundantBegin:
-  Enabled: true
+  Enabled: True
 
 Style/RescueModifier:
-  Enabled: true
+  Enabled: True
 
 # based on https://github.com/voxpupuli/modulesync_config/issues/168
 Style/RegexpLiteral:
   EnforcedStyle: percent_r
-  Enabled: true
+  Enabled: True
 
 Lint/UnderscorePrefixedVariableName:
-  Enabled: true
+  Enabled: True
 
 Metrics/ParameterLists:
-  Enabled: false
+  Enabled: False
 
 Lint/RequireParentheses:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceBeforeFirstArg:
-  Enabled: true
+  Enabled: True
 
 Style/ModuleFunction:
-  Enabled: true
+  Enabled: True
 
 Lint/Debugger:
-  Enabled: true
+  Enabled: True
 
 Style/IfWithSemicolon:
-  Enabled: true
+  Enabled: True
 
 Style/Encoding:
-  Enabled: true
+  Enabled: True
 
 Style/BlockDelimiters:
-  Enabled: true
+  Enabled: True
 
 Style/MultilineBlockLayout:
-  Enabled: true
+  Enabled: True
 
 # 'Complexity' is very relative
 Metrics/AbcSize:
@@ -494,10 +494,10 @@ Metrics/PerceivedComplexity:
   Enabled: False
 
 Lint/UselessAssignment:
-  Enabled: true
+  Enabled: True
 
 Style/ClosingParenthesisIndentation:
-  Enabled: false
+  Enabled: False
 
 # RSpec
 

--- a/moduleroot/.rubocop.yml
+++ b/moduleroot/.rubocop.yml
@@ -508,3 +508,6 @@ RSpec/DescribeClass:
 # Example length is not necessarily an indicator of code quality
 RSpec/ExampleLength:
   Enabled: False
+
+RSpec/NamedSubject:
+  Enabled: False

--- a/moduleroot/.travis.yml
+++ b/moduleroot/.travis.yml
@@ -47,7 +47,6 @@ matrix:
 <%   @configs['allow_failures'].each do |allow_failures| -%>
   allow_failures:
     - rvm: <%= allow_failures['rvm'] %>
-      env: <%= allow_failures['env'] %>
 <%   end -%>
 <% end -%>
 notifications:


### PR DESCRIPTION
Would be totally awesome if github could show here the text of all commits.

```
commit e5bb33c3e5eb13c999ebded2ba6474c0c487dd7c
Author: Tim Meusel <tim@bastelfreak.de>
Date:   Sun Aug 7 12:15:38 2016 +0200

    use capitalized bools
    
    We already used it a few times in the rubocop config. this patch makes
    it now consistent.
    (We could also go with lowercase here, I just prefer capitalized)


commit 13944658ab4a7ec7d61c006423d0ab25d4cb98f9
Author: Tim Meusel <tim@bastelfreak.de>
Date:   Sun Aug 7 12:10:43 2016 +0200

    disable RSpec/NamedSubject for now
    
    this is a complicated cop that isn't easy to fix. It got introduced in
    the last rubocop-rspec release. We also use it in a lot of modules so
    fixing is time consuming and breaks our modulesync. We already disabled
    the cop in https://github.com/voxpupuli/puppet-nodejs/pull/240 which
    created the expected result.
    lot of modules


commit b8141b95717d38f0d2051d089cb87483f4369e34
Author: Tim Meusel <tim@bastelfreak.de>
Date:   Sun Aug 7 12:00:13 2016 +0200

    bump rubocop-rspec to 1.6
    
    We already test with version 1.6 and updated our configs to reflect the
    changes. There are a few new cops that could break on older
    rubocop-rspec 1.5, so we should bump the requoired version. Initial 1.6
    support came in https://github.com/voxpupuli/modulesync_config/pull/204


commit 5c1ec77c6f4e016d3019d43308b95c2cf9064585
Author: Tim Meusel <tim@bastelfreak.de>
Date:   Sun Aug 7 11:48:08 2016 +0200

    add testing on ruby2.4.0
    
    this is becomming the new Ruby version in the near future. The rolling
    release distributions will soon update to it, so we should already test
    against it. It is still under development, so we enable allow_failures
    for it. Tested in https://github.com/voxpupuli/puppet-gluster/pull/60


commit 072f5d6112825d2a87d71afa7a93af3b11562dbd
Author: Tim Meusel <tim@bastelfreak.de>
Date:   Sun Aug 7 11:44:32 2016 +0200

    remove uesless env attribute from allow_failures
    
    this isn't needed here. We specify env + rvm version in our build
    matrix. allow_failures only needs to list the rvm version. This is
    tested in https://github.com/voxpupuli/puppet-gluster/pull/60 and
    documented at
    https://docs.travis-ci.com/user/customizing-the-build/#Rows-that-are-Allowed-to-Fail
```