### PR TITLE
(Re-)enable Style/ClosingParenthesisIndentation cop

### DIFF
--- a/moduleroot/.rubocop.yml
+++ b/moduleroot/.rubocop.yml
@@ -497,7 +497,7 @@ Lint/UselessAssignment:
   Enabled: True
 
 Style/ClosingParenthesisIndentation:
-  Enabled: False
+  Enabled: True
 
 # RSpec
 


### PR DESCRIPTION
It was enabled in ed0f3ce5 then apparently inadvertently disabled in d7e9b20c