### PR TITLE
Use puppetlabs_spec_helper's release_checks task

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -67,8 +67,6 @@ Rakefile:
   - 'disable_single_quote_string_with_variables'
   default_enabled_rake_targets:
   - 'metadata_lint'
-  - 'lint'
-  - 'syntax'
-  - 'spec'
+  - 'release_checks'
 ...
 # vim: syntax=yaml


### PR DESCRIPTION
The task runs the following tasks from puppetlabs_spec_helper:
* lint
* validate (which runs the syntax & metadata_lint tasks)
* spec
* check:symlinks
* check:test_file
* check:dot_underscore
* check:git_ignore

The last four are not currently checked by the default modulesync config.

I've left `metadata_lint` in the list of explicitly called tasks even though it's indirectly called by `release_checks` because puppetlabs_spec_helper only calls it if metadata.json exists, so it won't fail if it doesn't. Calling it directly fails if the file is missing. The downside to this is that metadata_lint will be run twice.

Alternately, these tasks could be added to the list of explicitly run Rake tasks, but if more tasks are added to puppetlabs_spec_helper's release_checks they won't be called here until manually added.

Task descriptions for the newly run tasks:
```
rake release_checks       # Runs all nessesary checks on a module in preparation for a release
rake validate             # Check syntax of Ruby files and call :syntax and :metadata_lint
rake check:dot_underscore # Fails if any ._ files are present in directory
rake check:git_ignore     # Fails if directories contain the files specified in .gitignore
rake check:symlinks       # Fails if symlinks are present in directory
rake check:test_file      # Fails if .pp files present in tests folder
```