### PR TITLE
Fix puppet-lint and dpl gem

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -36,6 +36,8 @@ Gemfile:
       - gem: puppet-lint-classes_and_types_beginning_with_digits-check
       - gem: puppet-lint-unquoted_string-check
       - gem: puppet-lint-variable_contains_upcase
+      - gem: puppet-lint
+        version: '2.0.0'
       - gem: metadata-json-lint
       - gem: puppet-blacksmith
       - gem: voxpupuli-release

--- a/moduleroot/.travis.yml
+++ b/moduleroot/.travis.yml
@@ -53,6 +53,8 @@ notifications:
   email: false
 deploy:
   provider: puppetforge
+  deploy:
+    branch: ha-bug-puppet-forge
   user: puppet
   password:
     secure: "<%= @configs['secure'] -%>"


### PR DESCRIPTION
git log messages:
```
commit 4c58c736e7f71baa6e6392b16ce800a697804a57
Author: Tim Meusel <tim@bastelfreak.de>
Date:   Fri Aug 19 11:02:40 2016 +0200

    pin puppet-lint to 2.0.0
    
    2.0.1 got released a few hours ago, the puppetlint-variablecase plugin
    isn't compatible with that:
    https://github.com/fiddyspence/puppetlint-variablecase/pull/6
    
    This workaround is tested in multiple releases, for example minecraft
    and mumble.

commit 9d3419624ba62e54b58881c100776fa5b8ef2d8d
Author: Tim Meusel <tim@bastelfreak.de>
Date:   Fri Aug 19 10:59:21 2016 +0200

    get dpl from specific branch
    
    During a release, travis installs the dpl gem. The latest released
    version is broken, the travis devs provided us a fix which is available
    in a certain branch: https://github.com/travis-ci/dpl/issues/487
    This fix is tested in several modules, fox example zabbix, gluster,
    minecraft
```