### PR TITLE
pin rubocop and rubocop-rspec depending on Ruby version

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -47,7 +47,15 @@ Gemfile:
       - gem: rubocop-rspec
         version: '~> 1.6'
         ruby-operator: '>='
-        ruby-version: '2.3.0'
+        ruby-version: '2.2.0'
+      - gem: rubocop-rspec
+        version: '1.5.0'
+        ruby-operator: '<'
+        ruby-version: '2.2.0'
+      - gem: rubocop
+        version: '0.41.2'
+        ruby-operator: '<'
+        ruby-version: '2.0.0'
       - gem: json_pure
         version: '<= 2.0.1'
         ruby-operator: '<'


### PR DESCRIPTION
This table shows the last supported versions of rubocop and rubocop-rspec against each Ruby version supported by the default modulesync config.

Ruby version|rubocop|rubocop-rspec
---|---|---
1.9.3|0.41.2|1.5.0
2.1|Supported|1.5.1
2.2|Supported|Supported
2.3|Supported|Supported

This PR sets the versions in line with the above, except for Ruby 2.1 which gets rubocop-rspec 1.5.0 even though it could get 1.5.1. There's nothing interesting in 1.5.1 so it was left out to reduce complexity of the config.

To summarize:
* Ruby 1.9.3 gets rubocop 0.41.2 and rubocop-rspec 1.5.0
* Ruby 2.1 gets latest rubocop and rubocop-rspec 1.5.0
* Ruby 2.2 and higher gets latest rubocop and rubocop-rspec 1.6.x