### PR TITLE
unpin puppet-lint

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -36,8 +36,6 @@ Gemfile:
       - gem: puppet-lint-classes_and_types_beginning_with_digits-check
       - gem: puppet-lint-unquoted_string-check
       - gem: puppet-lint-variable_contains_upcase
-      - gem: puppet-lint
-        version: '2.0.0'
       - gem: metadata-json-lint
       - gem: puppet-blacksmith
       - gem: voxpupuli-release


### PR DESCRIPTION
This got successfully tested here:
https://github.com/voxpupuli/puppet-stash/pull/125

We introduced it here:
https://github.com/voxpupuli/modulesync_config/commit/4c58c736e7f71baa6e6392b16ce800a697804a57
puppetlint-variablecase got updated so we don't need to pin it anymore