### PR TITLE
Create a DEPLOY_TO_FORGE constraint

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -12,7 +12,7 @@
   - rvm: 2.2
     env: PUPPET_VERSION="~> 4.0" CHECK=test
   - rvm: 2.3.1
-    env: PUPPET_VERSION="~> 4.0" CHECK=build
+    env: PUPPET_VERSION="~> 4.0" CHECK=build DEPLOY_TO_FORGE=yes
   - rvm: 2.3.1
     env: PUPPET_VERSION="~> 4.0" CHECK=rubocop
   - rvm: 2.3.1

--- a/moduleroot/.travis.yml
+++ b/moduleroot/.travis.yml
@@ -62,5 +62,5 @@ deploy:
     tags: true
     # all_branches is required to use tags
     all_branches: true
-    # Only publish if our main Ruby target builds
-    rvm: 2.3.1
+    # Only publish the build marked with "DEPLOY_TO_FORGE"
+    condition: "$DEPLOY_TO_FORGE = yes"


### PR DESCRIPTION
This adds a more visible condition to see whch job goes to forge. It is
also easier to avoid duplicates.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>