### PR TITLE
Make .gitignore fixtures more specific

### DIFF
--- a/moduleroot/.gitignore
+++ b/moduleroot/.gitignore
@@ -3,7 +3,8 @@ Gemfile.lock
 Gemfile.local
 vendor/
 .vendor/
-spec/fixtures/
+spec/fixtures/manifests/
+spec/fixtures/modules/
 .vagrant/
 .bundle/
 coverage/


### PR DESCRIPTION
It's quite valid to have directories in spec/fixtures that should be
part of what's committed.
eg in `puppet-archive` there is a `spec/fixtures/checksum` directory.

`spec/fixtures/manifests` and `spec/fixtures/modules` get populated by
`spec_prep` on the other hand.