### PR TITLE
Don't run rubocop on files in `files`

### DIFF
--- a/moduleroot/.rubocop.yml
+++ b/moduleroot/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
   Include:
     - ./**/*.rb
   Exclude:
+    - files/**/*
     - vendor/**/*
     - .vendor/**/*
     - pkg/**/*


### PR DESCRIPTION
Any ruby files in these directories are files that get deployed to
hosts.  We shouldn't be fixing violations in these.

For instance, a file might be being deployed by puppet 4 (ruby >1.8) to
a EL6 host (with system ruby 1.8).  We shouldn't be breaking ruby 1.8
support on files that are *deployed*.