### PR TITLE
Fix for latest `puppet-strings`

### DIFF
--- a/moduleroot/Rakefile
+++ b/moduleroot/Rakefile
@@ -1,7 +1,7 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet_blacksmith/rake_tasks'
 require 'voxpupuli/release/rake_tasks'
-require 'puppet-strings/rake_tasks'
+require 'puppet-strings/tasks'
 
 if RUBY_VERSION >= '2.3.0'
   require 'rubocop/rake_task'


### PR DESCRIPTION
https://github.com/puppetlabs/puppet-strings/pull/98 is massive, but I
think this is the most important thing we need to change right now.

Without this fix, we currently can't run *any* rake tasks.