### PR TITLE
Pin puppet-strings to 0.4.0

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -42,7 +42,7 @@ Gemfile:
       - gem: voxpupuli-release
         git: https://github.com/voxpupuli/voxpupuli-release-gem.git
       - gem: puppet-strings
-        git: https://github.com/puppetlabs/puppetlabs-strings.git
+        version: '0.4.0'
       - gem: rubocop-rspec
         version: '~> 1.6'
         ruby-operator: '>='


### PR DESCRIPTION
Following https://github.com/puppetlabs/puppet-strings/pull/98 all VP
builds were broken.  Pinning to the last release fixes them again.
Hopefully 1.0.0 of `puppet-strings` will be released in the next couple
of weeks.