### PR TITLE
add Ubuntu 16.04 as default nodeset

### DIFF
--- a/moduleroot/spec/acceptance/nodesets/default.yml
+++ b/moduleroot/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,12 @@
+---
+HOSTS:
+  ubuntu-server-1604-x64:
+    roles:
+      - master
+    platform: ubuntu-16.04-amd64
+    box: puppetlabs/ubuntu-16.04-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  type: foss
+...
+# vim: syntax=yaml


### PR DESCRIPTION
Using Ubuntu over CentOS might be contentious... not sure what's generally used more often.

But since these are typically used for automated testing Ubuntu seemed as good a choice as any.