### PR TITLE
Allow running acceptance tests on travis

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -1,18 +1,33 @@
 ---
 .travis.yml:
+  docker_sets:
+  docker_defaults:
+    # values will replace @@SET@@ with the docker_sets' value
+    rvm: 2.1.9
+    sudo: required
+    dist: trusty
+    services: docker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=@@SET@@ CHECK=beaker
+    bundler_args: --without development
   includes:
   - rvm: 2.1.9
     env: PUPPET_VERSION="~> 4.0" CHECK=test
+    bundler_args: --without system_tests development
   - rvm: 2.2.7
     env: PUPPET_VERSION="~> 4.0" CHECK=test
+    bundler_args: --without system_tests development
   - rvm: 2.3.4
     env: PUPPET_VERSION="~> 4.0" CHECK=test
+    bundler_args: --without system_tests development
   - rvm: 2.4.1
     env: PUPPET_VERSION="~> 4.0" CHECK=test
+    bundler_args: --without system_tests development
   - rvm: 2.4.1
     env: PUPPET_VERSION="~> 4.0" CHECK=rubocop
+    bundler_args: --without system_tests development
   - rvm: 2.4.1
     env: PUPPET_VERSION="~> 4.0" CHECK=build DEPLOY_TO_FORGE=yes
+    bundler_args: --without system_tests development
 Gemfile:
   required:
     ':test':

--- a/moduleroot/.travis.yml
+++ b/moduleroot/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 dist: trusty
 language: ruby
 cache: bundler
-bundler_args: --without system_tests development
 <%- if !@configs.nil? and @configs.has_key?('addons') -%>
 addons:
   <%- if @configs['addons'].has_key?('apt') -%>
@@ -34,29 +33,40 @@ script:
 matrix:
   fast_finish: true
   include:
+<% if @configs['docker_sets'] -%>
+<%   @configs['docker_sets'].each do |set| -%>
+<%     job = @configs['docker_defaults'].merge(set['options'] || {}) -%>
+  - rvm: <%= job['rvm'] %>
+<%     job.keys.sort.each do |k| -%>
+<%     next if k == 'rvm' -%>
+    <%= k %>: <%= job[k].gsub(/@@SET@@/, set['set']) %>
+<%     end -%>
+<%   end -%>
+<% end -%>
 <% @configs['includes'].each do |include| -%>
   - rvm: <%= include['rvm'] %>
-    env: <%= include['env'] %>
+<%   include.keys.sort.each do |k| -%>
+<%     next if k == 'rvm' -%>
+    <%= k %>: <%= include[k] %>
+<%   end -%>
 <% end -%>
 <% if @configs['extras'] -%>
 <%   @configs['extras'].each do |extra| -%>
   - rvm: <%= extra['rvm'] %>
-    env: <%= extra['env'] %>
-<%     if extra['services'] -%>
-    services: <%= extra['services'] %>
-<%     end -%>
-<%     if extra['sudo'] -%>
-    sudo: <%= extra['sudo'] %>
-<%     end -%>
-<%     if extra['bundler_args'] -%>
-    bundler_args: <%= extra['bundler_args'] %>
+<%     extra.keys.sort.each do |k| -%>
+<%       next if k == 'rvm' -%>
+    <%= k %>: <%= extra[k] %>
 <%     end -%>
 <%   end -%>
 <% end -%>
 <% if @configs['allow_failures'] -%>
-<%   @configs['allow_failures'].each do |allow_failures| -%>
   allow_failures:
-    - rvm: <%= allow_failures['rvm'] %>
+<%   @configs['allow_failures'].each do |allow_failure| -%>
+    - rvm: <%= allow_failure['rvm'] %>
+<%     allow_failure.keys.sort.each do |k| -%>
+<%       next if k == 'rvm' -%>
+      <%= k %>: <%= job[k] %>
+<%     end -%>
 <%   end -%>
 <% end -%>
 branches:


### PR DESCRIPTION
Closes https://github.com/voxpupuli/modulesync_config/issues/80

Full credit to Puppet from where this was lifted (https://github.com/puppetlabs/modulesync_configs/pull/58), with a couple of minor changes to ensure it fits better with the Voxpupuli Gemfile.

Tested with puppet-nginx module.

The biggest change compared with Puppet's version is that acceptance tests are NOT run by default. Each module would have to enable docker sets in their Travis file (see https://github.com/voxpupuli/puppet-nginx/pull/885/files#diff-f620401c6bdf661e1275316a6e01b62f for an example).

It's probably a good idea to enable by default in future but I thought it might be too disruptive right now.
