### PR TITLE
add a note about rubocop checks, since they're enforced

### DIFF
--- a/moduleroot/.github/CONTRIBUTING.md
+++ b/moduleroot/.github/CONTRIBUTING.md
@@ -52,6 +52,11 @@ check various syntax and style things. You can run these locally with:
     bundle exec rake lint
     bundle exec rake validate
 
+It will also run some [Rubocop](http://batsov.com/rubocop/) tests
+against it. You can run those locally ahead of time with:
+
+    bundle exec rake rubocop
+
 ## Running the unit tests
 
 The unit test suite covers most of the code, as mentioned above please
@@ -85,9 +90,9 @@ with:
     bundle exec rake acceptance
 
 This will run the tests on an Ubuntu 12.04 virtual machine. You can also
-run the integration tests against Centos 6.5 with.
+run the integration tests against Centos 6.6 with.
 
-    BEAKER_set=centos-64-x64 bundle exec rake acceptances
+    BEAKER_set=centos-66-x64 bundle exec rake acceptances
 
 If you don't want to have to recreate the virtual machine every time you
 can use `BEAKER_DESTROY=no` and `BEAKER_PROVISION=no`. On the first run you will


### PR DESCRIPTION
Since rubocop checks are enforced in Travis, there should be a note about this.