### PR TITLE
Use new key line over linenumber.

### DIFF
--- a/moduleroot/Rakefile
+++ b/moduleroot/Rakefile
@@ -12,7 +12,7 @@ if RUBY_VERSION >= '2.3.0'
   end
 end
 
-PuppetLint.configuration.log_format = '%{path}:%{linenumber}:%{check}:%{KIND}:%{message}'
+PuppetLint.configuration.log_format = '%{path}:%{line}:%{check}:%{KIND}:%{message}'
 PuppetLint.configuration.fail_on_warnings = true
 <% checks = @configs['default_disabled_lint_checks'] + ( @configs['extra_disabled_lint_checks'] || [] ) -%>
 <% checks.each do |check| -%>


### PR DESCRIPTION
Fixes where you can run into  the error below.

The puppet-lint deprecation

http://github.com/rodjek/puppet-lint/pull/540

has been merged into master.

According to

https://github.com/rodjek/puppet-lint/issues/539

it was meant to be added at version 3 but is now merged
with 2.0.2.

Thanks @Feandil for diagnosis.

```
rake aborted!
KeyError: key{linenumber} not found
/afs/cern.ch/user/s/straylen/.gem/ruby/bundler/gems/puppet-lint-32e93d43a3bf/lib/puppet-lint.rb:102:in
`%'
/afs/cern.ch/user/s/straylen/.gem/ruby/bundler/gems/puppet-lint-32e93d43a3bf/lib/puppet-lint.rb:102:in
`format_message'
/afs/cern.ch/user/s/straylen/.gem/ruby/bundler/gems/puppet-lint-32e93d43a3bf/lib/puppet-lint.rb:136:in
`block in report'
```