### PR TITLE
pin mocha to 1.1.0

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -51,6 +51,8 @@ Gemfile:
         version: '<= 2.0.1'
         ruby-operator: '<'
         ruby-version: '2.0.0'
+      - gem: mocha
+        version: '1.1.0'
     ':development':
       - gem: travis
       - gem: travis-lint


### PR DESCRIPTION
see https://github.com/freerange/mocha/issues/272
TL;DR: 1.2.0 is broken on ruby231 so we need to stay on the older
release