### PR TITLE
Add support for additional parameters

### DIFF
--- a/moduleroot/.travis.yml
+++ b/moduleroot/.travis.yml
@@ -41,6 +41,15 @@ matrix:
 <%   @configs['extras'].each do |extra| -%>
   - rvm: <%= extra['rvm'] %>
     env: <%= extra['env'] %>
+<%     if extra['services'] -%>
+    services: <%= extra['services'] %>
+<%     end -%>
+<%     if extra['sudo'] -%>
+    sudo: <%= extra['sudo'] %>
+<%     end -%>
+<%     if extra['bundler_args'] -%>
+    bundler_args: <%= extra['bundler_args'] %>
+<%     end -%>
 <%   end -%>
 <% end -%>
 <% if @configs['allow_failures'] -%>


### PR DESCRIPTION
This is an requirement to restore the additional build steps (Beaker) of the Corosync module https://github.com/voxpupuli/puppet-corosync/pull/380.