### PR TITLE
RFC: Disable Metric/BlockLength cop

### DIFF
--- a/moduleroot/.rubocop.yml
+++ b/moduleroot/.rubocop.yml
@@ -62,6 +62,9 @@ Style/AndOr:
 Style/RedundantSelf:
   Enabled: True
 
+Metric/BlockLength:
+  Enabled: False
+
 # Method length is not necessarily an indicator of code quality
 Metrics/MethodLength:
   Enabled: False


### PR DESCRIPTION
`Metric/BlockLength` is a new cop in rubocop 0.44.
https://github.com/bbatsov/rubocop/issues/3566

All puppet type definitions occur in blocks that are almost always
longer than 25 lines.  I don't see much benefit in having the cop
enabled, and then having to disable it with control comments instead.
