### PR TITLE
require at least mocha 1.2.1

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -54,7 +54,7 @@ Gemfile:
         ruby-operator: '<'
         ruby-version: '2.0.0'
       - gem: mocha
-        version: '1.1.0'
+        version: '>= 1.2.1'
     ':development':
       - gem: travis
       - gem: travis-lint


### PR DESCRIPTION
1.2.0 had a bug on ruby231:
https://github.com/freerange/mocha/issues/272
we pinned it to 1.1.0 which was the last known working version. 1.2.1
contains a fix