### PR TITLE
Add support for Coveralls

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -55,6 +55,7 @@ Gemfile:
         ruby-version: '2.0.0'
       - gem: mocha
         version: '>= 1.2.1'
+      - gem: coveralls
     ':development':
       - gem: travis
       - gem: travis-lint

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -56,6 +56,8 @@ Gemfile:
       - gem: mocha
         version: '>= 1.2.1'
       - gem: coveralls
+        ruby-operator: '>='
+        ruby-version: '2.0.0'
     ':development':
       - gem: travis
       - gem: travis-lint

--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -1,8 +1,11 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 include RspecPuppetFacts
-require 'coveralls'
-Coveralls.wear!
+
+unless RUBY_VERSION =~ %r{^1.9}
+  require 'coveralls'
+  Coveralls.wear!
+end
 
 RSpec.configure do |c|
   default_facts = {

--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 include RspecPuppetFacts
+require 'coveralls'
+Coveralls.wear!
 
 RSpec.configure do |c|
   default_facts = {


### PR DESCRIPTION
This will allow us to use more badges at the REAMDE.md. In this case it will show use the percentage of the code coverage for RSpec tests.

![badges](https://cloud.githubusercontent.com/assets/1111056/19552094/a0c20164-96ae-11e6-8578-878fc8d6ae6a.jpg)

For example: https://coveralls.io/github/voxpupuli/puppet-collectd

We already use this for some of our repositories: https://coveralls.io/github/voxpupuli/puppet-lint-classes_and_types_beginning_with_digits-check