### PR TITLE
Add .yardoc to moduleroot/.gitignore

### DIFF
--- a/moduleroot/.gitignore
+++ b/moduleroot/.gitignore
@@ -12,6 +12,7 @@ log/
 .idea/
 *.iml
 .*.sw
+.yardoc/
 <% if ! @configs['paths'].nil? -%>
 <% @configs['paths'].each do |path| -%>
 <%= path %>


### PR DESCRIPTION
This is already ignored in the repo's own .gitignore, along with some other doc related ones. If we start using puppet-strings for docs, we're probably going to want to have this in our generic .gitignore also.