### PR TITLE
use latest rspec-puppet release

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -27,7 +27,7 @@ Gemfile:
       - gem: puppetlabs_spec_helper
         version: '~> 1.2.2'
       - gem: rspec-puppet
-        git: https://github.com/rodjek/rspec-puppet.git
+        version: '~> 2.5'
       - gem: rspec-puppet-facts
       - gem: rspec-puppet-utils
       - gem: puppet-lint-absolute_classname-check


### PR DESCRIPTION
2.5.0 got released today:
https://rubygems.org/gems/rspec-puppet/versions/2.5.0

no need anymore to pull it from git.