### PR TITLE
drop testing on ruby225

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -9,8 +9,6 @@
     env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
   - rvm: 2.1.9
     env: PUPPET_VERSION="~> 4.0" CHECK=test
-  - rvm: 2.2.5
-    env: PUPPET_VERSION="~> 4.0" CHECK=test
   - rvm: 2.3.1
     env: PUPPET_VERSION="~> 4.0" CHECK=build DEPLOY_TO_FORGE=yes
   - rvm: 2.3.1


### PR DESCRIPTION
I don't think that this is really useful. Puppet AIO ships ruby21 for
the agent, and the latest Ruby, which is used in all the modern
distributions, is ruby231.