### PR TITLE
Remove SimpleCove filter

### DIFF
--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -6,13 +6,14 @@ unless RUBY_VERSION =~ %r{^1.9}
   require 'coveralls'
   require 'simplecov'
   require 'simplecov-console'
+
   SimpleCov.formatters = [
     SimpleCov::Formatter::HTMLFormatter,
     SimpleCov::Formatter::Console,
     Coveralls::SimpleCov::Formatter
   ]
   SimpleCov.start do
-    add_filter '/spec'
+   add_filter 'spec/fixtures'
   end
 end
 


### PR DESCRIPTION
The SimpleCov filter is not necessary and will result in the following report.

```
Coverage report generated for RSpec to ../coverage. 0.0 / 0.0 LOC (100.0%) covered.

COVERAGE: 100.00% -- 0.0/0.0 lines in 0 files
```

As you can see, no file will be processed and the module will always have a coverage of 100%.