### PR TITLE
Revert "Fix SimpleCove filter"

### DIFF
--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -6,14 +6,13 @@ unless RUBY_VERSION =~ %r{^1.9}
   require 'coveralls'
   require 'simplecov'
   require 'simplecov-console'
-
   SimpleCov.formatters = [
     SimpleCov::Formatter::HTMLFormatter,
     SimpleCov::Formatter::Console,
     Coveralls::SimpleCov::Formatter
   ]
   SimpleCov.start do
-   add_filter 'spec/fixtures'
+    add_filter '/spec'
   end
 end
 


### PR DESCRIPTION
This reverts commit 152e345be5669b598cbb3d26d8ddbffd88d4a7b4. https://github.com/voxpupuli/modulesync_config/pull/263

Since this is a revert and might be controversial, I don't want it merged unless there first is a consensus.
I think @bastelfreak thinks we should probably revert, but I'd like to see some other people comment too.