### PR TITLE
Improve simplecov

### DIFF
--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 include RspecPuppetFacts
 
-unless RUBY_VERSION =~ %r{^1.9}
+if Dir.exist?(File.expand_path('../../lib', __FILE__)) && RUBY_VERSION !~ %r{^1.9}
   require 'coveralls'
   require 'simplecov'
   require 'simplecov-console'
@@ -12,6 +12,7 @@ unless RUBY_VERSION =~ %r{^1.9}
     Coveralls::SimpleCov::Formatter
   ]
   SimpleCov.start do
+    track_files 'lib/**/*.rb'
     add_filter '/spec'
   end
 end


### PR DESCRIPTION
Don't run simplecov at all if the module has no `lib` directory.
This should fix a github coveralls integration issue.  Coveralls seems
to get upset and never reports back to travis if we send it reports
about 0 files.

Include all ruby files under `lib` in the coverage report, even those
with 0% coverage.