### PR TITLE
Only CI test 'push' builds on master.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,6 @@ matrix:
   - rvm: 2.1.9
   - rvm: 2.2.5
   - rvm: 2.3.1
+branches:
+  only:
+  - master

--- a/moduleroot/.travis.yml
+++ b/moduleroot/.travis.yml
@@ -58,6 +58,9 @@ matrix:
     - rvm: <%= allow_failures['rvm'] %>
 <%   end -%>
 <% end -%>
+branches:
+  only:
+  - master
 notifications:
   email: false
 deploy:


### PR DESCRIPTION
Fixes #50

This restricts TravisCI to build all PRs and pushes/merges to the branch master (including tags), no other branches will have CI builds. The primary goal is to stop double builds on PRs (one push, one pr).