### PR TITLE
Remove selinux_config_mode from default facts

### DIFF
--- a/moduleroot/spec/default_facts.yml
+++ b/moduleroot/spec/default_facts.yml
@@ -3,4 +3,3 @@ concat_basedir: "/tmp"
 ipaddress: "172.16.254.254"
 is_pe: false
 macaddress: "AA:AA:AA:AA:AA:AA"
-selinux_config_mode: "disabled"


### PR DESCRIPTION
This fact doesn't always exist on systems and having it as a default
fact is masking strict variable issues.