### PR TITLE
add safe_yaml ~> 1.0.4

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -61,6 +61,8 @@ Gemfile:
       - gem: simplecov-console
         ruby-operator: '>='
         ruby-version: '2.0.0'
+      - gem: safe_yaml
+        version: '~> 1.0.4'
     ':development':
       - gem: travis
       - gem: travis-lint


### PR DESCRIPTION
Let me know if this is the right place within the file
See:
https://tickets.puppetlabs.com/browse/PUP-3796
But basically, this seems to avoid a problem with rake where PUPPET_VERSION="~> 3.0" is set, but Ruby is >= 2.2.x

```
% bundle exec rake 
rake aborted!
NameError: uninitialized constant Syck
/usr/local/lib/ruby/gems/2.3.0/gems/puppet-3.8.7/lib/puppet/vendor/safe_yaml/lib/safe_yaml/syck_node_monkeypatch.rb:42:in `<top (required)>'
/usr/local/lib/ruby/gems/2.3.0/gems/puppet-3.8.7/lib/puppet/vendor/safe_yaml/lib/safe_yaml.rb:197:in `require'
/usr/local/lib/ruby/gems/2.3.0/gems/puppet-3.8.7/lib/puppet/vendor/safe_yaml/lib/safe_yaml.rb:197:in `<module:YAML>'
[...]
%  ruby --version
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin15]
```