### PR TITLE
Add nodesets for Fedora 24 and 25

### DIFF
--- a/moduleroot/spec/acceptance/nodesets/fedora-24-x64.yml
+++ b/moduleroot/spec/acceptance/nodesets/fedora-24-x64.yml
@@ -1,0 +1,15 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
+HOSTS:
+  fedora-24-x64:
+    roles:
+      - master
+    platform: fedora-24-x86_64
+    box: fedora/24-cloud-base
+    hypervisor: vagrant
+CONFIG:
+  type: aio
+...
+# vim: syntax=yaml

--- a/moduleroot/spec/acceptance/nodesets/fedora-25-x64.yml
+++ b/moduleroot/spec/acceptance/nodesets/fedora-25-x64.yml
@@ -1,0 +1,18 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
+#
+# platform is fedora 24 because there is no
+# puppet-agent for fedora 25 by 2016-12-30
+HOSTS:
+  fedora-25-x64:
+    roles:
+      - master
+    platform: fedora-24-x86_64
+    box: fedora/25-cloud-base
+    hypervisor: vagrant
+CONFIG:
+  type: aio
+...
+# vim: syntax=yaml


### PR DESCRIPTION
These nodesets use fedoraproject images because Puppet does not
provide vagrant boxes for Fedora.

The main difference to the puppet boxes:

* they are shipped with SELinux enabled and enforcing
* they are updated regularly

Successfully ran acceptance tests from the puppet-selinux module
whith these nodesets.