### PR TITLE
Bump Rubocop gems to specific versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ source "https://rubygems.org"
 
 group :test do
   gem 'rake'
-  gem 'rubocop', '~> 0.39'
+  gem 'rubocop', '~> 0.46.0'
 end
 
 group :development do

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -46,7 +46,7 @@ Gemfile:
       - gem: puppet-strings
         version: '~> 0.99.0'
       - gem: rubocop-rspec
-        version: '~> 1.6'
+        version: '~> 1.9.0'
         ruby-operator: '>='
         ruby-version: '2.3.0'
       - gem: json_pure


### PR DESCRIPTION
The pinning basically was pinned to 1.0.0 > Ver >= 0.39.0 on rubocop and 2.0.0 > Ver >= 1.6.0 on rubocop-rspec which is a bit reckless, As such I have pinned to latest minor allowing for patch, this mimics the rest of the gem dependencies in principle.