### PR TITLE
Add github_changelog_generator to moduleroot Gemfile/Rakefile

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -45,6 +45,17 @@ Gemfile:
         version: '>= 1.2.1'
       - gem: coveralls
       - gem: simplecov-console
+      - gem: github_changelog_generator
+        version: '~> 1.13.0'
+        ruby-operator: '<'
+        ruby-version: '2.2.2'
+      - gem: rack
+        version: '~> 1.0'
+        ruby-operator: '<'
+        ruby-version: '2.2.2'
+      - gem: github_changelog_generator
+        ruby-operator: '>='
+        ruby-version: '2.2.2'
     ':development':
       - gem: travis
       - gem: travis-lint

--- a/moduleroot/Rakefile
+++ b/moduleroot/Rakefile
@@ -36,4 +36,15 @@ task test: [
   :<%= t %>,
 <% end -%>
 ]
+
+begin
+  require 'github_changelog_generator/task'
+  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+    version = (Blacksmith::Modulefile.new).version
+    config.future_release = "#{version}"
+    config.header = "# Change log\n\nAll notable changes to this project will be documented in this file.\nEach new release typically also includes the latest modulesync defaults.\nThese should not impact the functionality of the module."
+    config.exclude_labels = %w{duplicate question invalid wontfix modulesync}
+  end
+rescue LoadError
+end
 # vim: syntax=ruby


### PR DESCRIPTION
Test msync performed at https://github.com/voxpupuli/puppet-r10k/pull/328. It re-ordered some of the relevant gems but that was expected. The changelog task works as well:
```
[rnelson0@build03 r10k:modulesync]$ be rake changelog
Can't detect user and name from first parameter: 'changelog' -> exit'
Found 62 tags
Fetching tags dates: 62/62
Sorting tags...
Received issues: 308
Fetching merged dates: 199
Filtered pull requests: 153
Filtered issues: 96
Fetching events for issues and PR: 249
Fetching closed dates for issues: Done!
Generating log...
Done!
Generated log placed in /home/rnelson0/tmp/r10k/CHANGELOG.md
[rnelson0@build03 r10k:modulesync±]$ git diff
diff --git a/CHANGELOG.md b/CHANGELOG.md
index d4e5654..332cb84 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not impact the functionality of the module.

+## [4.1.1-rc0](https://github.com/voxpupuli/puppet-r10k/tree/4.1.1-rc0) (2017-01-12)
+[Full Changelog](https://github.com/voxpupuli/puppet-r10k/compare/v4.1.0...4.1.1-rc0)
+
+**Closed issues:**
+
+- Document breaking changes in CHANGELOG [\#306](https://github.com/voxpupuli/puppet-r10k/issues/306)
+- Status 42, OK, but it doesn't completely work [\#261](https://github.com/voxpupuli/puppet-r10k/issues/261)
+- \(enhancement\) pre-commit hook only validates what's on disk [\#234](https://github.com/voxpupuli/puppet-r10k/issues/234)
+
+**Merged pull requests:**
+
+- Better document soft dependency abrader/gms [\#327](https://github.com/voxpupuli/puppet-r10k/pull/327) ([rnelson0](https://github.com/rnelson0))
+
 ## [v4.1.0](https://github.com/voxpupuli/puppet-r10k/tree/v4.1.0) (2017-01-06)
 [Full Changelog](https://github.com/voxpupuli/puppet-r10k/compare/v4.0.2...v4.1.0)

@@ -15,11 +28,10 @@ These should not impact the functionality of the module.

 **Merged pull requests:**

+- Release 4.1.0 [\#325](https://github.com/voxpupuli/puppet-r10k/pull/325) ([rnelson0](https://github.com/rnelson0))
 - \(GH323\) Better parameterization of root user/group from \#279 [\#324](https://github.com/voxpupuli/puppet-r10k/pull/324) ([rnelson0](https://github.com/rnelson0))
 - Fix rubocop failures from \#268 [\#322](https://github.com/voxpupuli/puppet-r10k/pull/322) ([rnelson0](https://github.com/rnelson0))
-- modulesync 0.16.7 [\#320](https://github.com/voxpupuli/puppet-r10k/pull/320) ([bastelfreak](https://github.com/bastelfreak))
 - Bump minimum version dependencies \(for Puppet 4\) [\#318](https://github.com/voxpupuli/puppet-r10k/pull/318) ([juniorsysadmin](https://github.com/juniorsysadmin))
-- modulesync 0.16.6 [\#317](https://github.com/voxpupuli/puppet-r10k/pull/317) ([bastelfreak](https://github.com/bastelfreak))
 - Bump puppet minimum version\_requirement to 3.8.7 [\#315](https://github.com/voxpupuli/puppet-r10k/pull/315) ([juniorsysadmin](https://github.com/juniorsysadmin))
 - \[284\] Replace hard-coded version 1.5.1 with installed [\#308](https://github.com/voxpupuli/puppet-r10k/pull/308) ([rnelson0](https://github.com/rnelson0))
 - use puppet/make instead of deprecated croddy/make [\#307](https://github.com/voxpupuli/puppet-r10k/pull/307) ([croddy](https://github.com/croddy))
```