### PR TITLE
move main jobs to ruby240

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -6,15 +6,13 @@
   - rvm: 2.2.6
     env: PUPPET_VERSION="~> 4.0" CHECK=test
   - rvm: 2.3.3
-    env: PUPPET_VERSION="~> 4.0" CHECK=build DEPLOY_TO_FORGE=yes
-  - rvm: 2.3.3
-    env: PUPPET_VERSION="~> 4.0" CHECK=rubocop
-  - rvm: 2.3.3
     env: PUPPET_VERSION="~> 4.0" CHECK=test
   - rvm: 2.4.0
     env: PUPPET_VERSION="~> 4.0" CHECK=test
-  allow_failures:
-    - rvm: 2.4.0
+  - rvm: 2.4.0
+    env: PUPPET_VERSION="~> 4.0" CHECK=rubocop
+  - rvm: 2.4.0
+    env: PUPPET_VERSION="~> 4.0" CHECK=build DEPLOY_TO_FORGE=yes
 Gemfile:
   required:
     ':test':


### PR DESCRIPTION
the json people published json185. This is a new 1.X version that works
with ruby240. Ruby240 brings several speed improvements so jobs should
be finished faster. This was tested at
https://github.com/voxpupuli/puppet-splunk/pull/83