### PR TITLE
Changes for puppet strings

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -35,6 +35,7 @@ Gemfile:
         git: https://github.com/voxpupuli/voxpupuli-release-gem.git
       - gem: puppet-strings
         version: '~> 1.0.0'
+      - gem: redcarpet
       - gem: rubocop-rspec
         version: '~> 1.9.0'
         ruby-operator: '>='

--- a/moduleroot/.yardopts
+++ b/moduleroot/.yardopts
@@ -1,1 +1,2 @@
 --markup markdown
+--output-dir docs/


### PR DESCRIPTION
* puppet strings requires the redcarpet gem to handle markdown content
* Github Pages expects the documentation in docs/ folder