### PR TITLE
pin rubocop/rubocop-rspec

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -36,8 +36,12 @@ Gemfile:
       - gem: puppet-strings
         version: '~> 1.0.0'
       - gem: redcarpet
+      - gem: rubocop
+        version: '~> 0.47.0'
+        ruby-operator: '>='
+        ruby-version: '2.3.0'
       - gem: rubocop-rspec
-        version: '~> 1.9.0'
+        version: '~> 1.10.0'
         ruby-operator: '>='
         ruby-version: '2.3.0'
       - gem: mocha


### PR DESCRIPTION
we updated our .rubocop.yml. The new settings only work with the latest
release. also we should pin it so it doesn't break in the future