### PR TITLE
Use `YAML.safe_load`, re-enable Rubocop check

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,3 @@ Metrics/LineLength:
 # dealbreaker:
 Style/TrailingCommaInArguments:
   Enabled: false
-
-# Disable warnings on moduleroot/spec/spec_helper.rb and other files
-Security/YAMLLoad:
-  Enabled: false

--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -24,8 +24,8 @@ RSpec.configure do |c|
     puppetversion: Puppet.version,
     facterversion: Facter.version
   }
-  default_facts.merge!(YAML.load(File.read(File.expand_path('../default_facts.yml', __FILE__)))) if File.exist?(File.expand_path('../default_facts.yml', __FILE__))
-  default_facts.merge!(YAML.load(File.read(File.expand_path('../default_module_facts.yml', __FILE__)))) if File.exist?(File.expand_path('../default_module_facts.yml', __FILE__))
+  default_facts.merge!(YAML.safe_load(File.read(File.expand_path('../default_facts.yml', __FILE__)))) if File.exist?(File.expand_path('../default_facts.yml', __FILE__))
+  default_facts.merge!(YAML.safe_load(File.read(File.expand_path('../default_module_facts.yml', __FILE__)))) if File.exist?(File.expand_path('../default_module_facts.yml', __FILE__))
   c.default_facts = default_facts
   <%- if @configs['mock_with'] -%>
   c.mock_with <%= @configs['mock_with'] %>


### PR DESCRIPTION
This commit replaces calls to `YAML.load` in `spec/spec_helper.rb` with
calls to `YAML.safe_load` and re-enables the related Rubocop check in
the modulesync_config base directory.  Prior to this, because the cop
was not disabled in the module root, modules synced to this repo would
fail Rubocop checks while this modulesync_config repo would pass.  A
change in code was prefered here, because the check is a security check
rather than style, lint, or metrics check, and the code change has no
effect on the outcome of the spec helper.