### PR TITLE
Add CentOS 6 and 7 beaker nodesets

### DIFF
--- a/moduleroot/spec/acceptance/nodesets/centos-6-x64.yml
+++ b/moduleroot/spec/acceptance/nodesets/centos-6-x64.yml
@@ -1,0 +1,15 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
+HOSTS:
+  centos-6-x64:
+    roles:
+      - master
+    platform: el-6-x86_64
+    box: centos/6
+    hypervisor: vagrant
+CONFIG:
+  type: aio
+...
+# vim: syntax=yaml

--- a/moduleroot/spec/acceptance/nodesets/centos-7-x64.yml
+++ b/moduleroot/spec/acceptance/nodesets/centos-7-x64.yml
@@ -1,0 +1,15 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
+HOSTS:
+  centos-7-x64:
+    roles:
+      - master
+    platform: el-7-x86_64
+    box: centos/7
+    hypervisor: vagrant
+CONFIG:
+  type: aio
+...
+# vim: syntax=yaml


### PR DESCRIPTION
These use vagrant boxes provided by the distro itself.

Puppetlabs boxes are out of date whereas the distro box is
maintained.

The main difference to the puppetlabs boxes is IMHO that
SELinux is enforcing (which is the default when installing
the OS). The puppetlabs boxes had SELinux disabled.