### PR TITLE
Add Amazon Linux EC2 example beaker nodeset

### DIFF
--- a/moduleroot/spec/acceptance/nodesets/ec2/amazonlinux-2016091.yml
+++ b/moduleroot/spec/acceptance/nodesets/ec2/amazonlinux-2016091.yml
@@ -1,0 +1,31 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
+# 
+# Additional ~/.fog config file with AWS EC2 credentials
+# required.
+#
+# see: https://github.com/puppetlabs/beaker/blob/master/docs/how_to/hypervisors/ec2.md
+#
+# Amazon Linux is not a RHEL clone.
+#
+HOSTS:
+  amazonlinux-2016091-x64:
+    roles:
+      - master
+    platform: centos-6-x86_64
+    hypervisor: ec2
+    # refers to image_tempaltes.yaml AMI[vmname] entry:
+    vmname: amazonlinux-2016091-eu-central-1
+    # refers to image_tempaltes.yaml entry inside AMI[vmname][:image]:
+    snapshot: aio
+    # t2.micro is free tier eligible (https://aws.amazon.com/en/free/):
+    amisize: t2.micro
+    # required so that beaker sanitizes sshd_config and root authorized_keys:
+    user: ec2-user
+CONFIG:
+  type: aio
+  :ec2_yaml: spec/acceptance/nodesets/ec2/image_templates.yaml
+...
+# vim: syntax=yaml

--- a/moduleroot/spec/acceptance/nodesets/ec2/image_templates.yaml
+++ b/moduleroot/spec/acceptance/nodesets/ec2/image_templates.yaml
@@ -1,0 +1,14 @@
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
+#
+# see also: https://github.com/puppetlabs/beaker/blob/master/docs/how_to/hypervisors/ec2.md
+#
+# Hint: image IDs (ami-*) for the same image are different per location.
+#
+AMI:
+  # Amazon Linux AMI 2016.09.1 (HVM), SSD Volume Type 
+  amazonlinux-2016091-eu-central-1:
+    :image:
+      :aio: ami-af0fc0c0
+    :region: eu-central-1


### PR DESCRIPTION
Beaker supports EC2 as hypervisor and Amazon provides some free
resources. Registration and credentials required.

Other distros than Amazon Linux could be added/configured.