### PR TITLE
Add more beaker ec2 nodesets

### DIFF
--- a/moduleroot/spec/acceptance/nodesets/ec2/image_templates.yaml
+++ b/moduleroot/spec/acceptance/nodesets/ec2/image_templates.yaml
@@ -12,3 +12,23 @@ AMI:
     :image:
       :aio: ami-af0fc0c0
     :region: eu-central-1
+  # Red Hat Enterprise Linux 7.3 (HVM), SSD Volume Type
+  rhel-73-eu-central-1:
+    :image:
+      :aio: ami-e4c63e8b
+    :region: eu-central-1
+  # SUSE Linux Enterprise Server 12 SP2 (HVM), SSD Volume Type
+  sles-12sp2-eu-central-1:
+    :image:
+      :aio: ami-c425e4ab
+    :region: eu-central-1
+  # Ubuntu Server 16.04 LTS (HVM), SSD Volume Type
+  ubuntu-1604-eu-central-1:
+    :image:
+      :aio: ami-fe408091
+    :region: eu-central-1
+  # Microsoft Windows Server 2016 Base
+  windows-2016-base-eu-central-1:
+    :image:
+      :aio: ami-88ec20e7
+    :region: eu-central-1

--- a/moduleroot/spec/acceptance/nodesets/ec2/rhel-73-x64.yml
+++ b/moduleroot/spec/acceptance/nodesets/ec2/rhel-73-x64.yml
@@ -1,0 +1,29 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
+# 
+# Additional ~/.fog config file with AWS EC2 credentials
+# required.
+#
+# see: https://github.com/puppetlabs/beaker/blob/master/docs/how_to/hypervisors/ec2.md
+#
+HOSTS:
+  rhel-73-x64:
+    roles:
+      - master
+    platform: el-7-x86_64
+    hypervisor: ec2
+    # refers to image_tempaltes.yaml AMI[vmname] entry:
+    vmname: rhel-73-eu-central-1
+    # refers to image_tempaltes.yaml entry inside AMI[vmname][:image]:
+    snapshot: aio
+    # t2.micro is free tier eligible (https://aws.amazon.com/en/free/):
+    amisize: t2.micro
+    # required so that beaker sanitizes sshd_config and root authorized_keys:
+    user: ec2-user
+CONFIG:
+  type: aio
+  :ec2_yaml: spec/acceptance/nodesets/ec2/image_templates.yaml
+...
+# vim: syntax=yaml

--- a/moduleroot/spec/acceptance/nodesets/ec2/sles-12sp2-x64.yml
+++ b/moduleroot/spec/acceptance/nodesets/ec2/sles-12sp2-x64.yml
@@ -1,0 +1,29 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
+# 
+# Additional ~/.fog config file with AWS EC2 credentials
+# required.
+#
+# see: https://github.com/puppetlabs/beaker/blob/master/docs/how_to/hypervisors/ec2.md
+#
+HOSTS:
+  sles-12sp2-x64:
+    roles:
+      - master
+    platform: sles-12-x86_64
+    hypervisor: ec2
+    # refers to image_tempaltes.yaml AMI[vmname] entry:
+    vmname: sles-12sp2-eu-central-1
+    # refers to image_tempaltes.yaml entry inside AMI[vmname][:image]:
+    snapshot: aio
+    # t2.micro is free tier eligible (https://aws.amazon.com/en/free/):
+    amisize: t2.micro
+    # required so that beaker sanitizes sshd_config and root authorized_keys:
+    user: ec2-user
+CONFIG:
+  type: aio
+  :ec2_yaml: spec/acceptance/nodesets/ec2/image_templates.yaml
+...
+# vim: syntax=yaml

--- a/moduleroot/spec/acceptance/nodesets/ec2/ubuntu-1604-x64.yml
+++ b/moduleroot/spec/acceptance/nodesets/ec2/ubuntu-1604-x64.yml
@@ -1,0 +1,29 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
+# 
+# Additional ~/.fog config file with AWS EC2 credentials
+# required.
+#
+# see: https://github.com/puppetlabs/beaker/blob/master/docs/how_to/hypervisors/ec2.md
+#
+HOSTS:
+  ubuntu-1604-x64:
+    roles:
+      - master
+    platform: ubuntu-16.04-amd64
+    hypervisor: ec2
+    # refers to image_tempaltes.yaml AMI[vmname] entry:
+    vmname: ubuntu-1604-eu-central-1
+    # refers to image_tempaltes.yaml entry inside AMI[vmname][:image]:
+    snapshot: aio
+    # t2.micro is free tier eligible (https://aws.amazon.com/en/free/):
+    amisize: t2.micro
+    # required so that beaker sanitizes sshd_config and root authorized_keys:
+    user: ubuntu
+CONFIG:
+  type: aio
+  :ec2_yaml: spec/acceptance/nodesets/ec2/image_templates.yaml
+...
+# vim: syntax=yaml

--- a/moduleroot/spec/acceptance/nodesets/ec2/windows-2016-base-x64.yml
+++ b/moduleroot/spec/acceptance/nodesets/ec2/windows-2016-base-x64.yml
@@ -1,0 +1,29 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
+# 
+# Additional ~/.fog config file with AWS EC2 credentials
+# required.
+#
+# see: https://github.com/puppetlabs/beaker/blob/master/docs/how_to/hypervisors/ec2.md
+#
+HOSTS:
+  windows-2016-base-x64:
+    roles:
+      - master
+    platform: windows-2016-64
+    hypervisor: ec2
+    # refers to image_tempaltes.yaml AMI[vmname] entry:
+    vmname: windows-2016-base-eu-central-1
+    # refers to image_tempaltes.yaml entry inside AMI[vmname][:image]:
+    snapshot: aio
+    # t2.micro is free tier eligible (https://aws.amazon.com/en/free/):
+    amisize: t2.micro
+    # required so that beaker sanitizes sshd_config and root authorized_keys:
+    user: ec2-user
+CONFIG:
+  type: aio
+  :ec2_yaml: spec/acceptance/nodesets/ec2/image_templates.yaml
+...
+# vim: syntax=yaml


### PR DESCRIPTION
Includes Windows 2016 Base, Ubuntu 16.04, SLES 12 SP2 and
RHEL 7.3

All eligible for the AWS EC2 free tier.

RHEL 7.3 worked fine with puppet-selinux acceptance tests.

SLES and Ubuntu started. 

Windows not tested - but maybe we have Windows modules which could run acceptance tests with EC2?