### PR TITLE
Update Fedora 25 beaker nodeset

### DIFF
--- a/moduleroot/spec/acceptance/nodesets/fedora-25-x64.yml
+++ b/moduleroot/spec/acceptance/nodesets/fedora-25-x64.yml
@@ -9,7 +9,7 @@ HOSTS:
   fedora-25-x64:
     roles:
       - master
-    platform: fedora-24-x86_64
+    platform: fedora-25-x86_64
     box: fedora/25-cloud-base
     hypervisor: vagrant
 CONFIG:


### PR DESCRIPTION
Set platform to correct version as puppet-agent 1.9 officially
supports Fedora 25 now.