### PR TITLE
Enable Hiera in spec tests

### DIFF
--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -30,6 +30,9 @@ RSpec.configure do |c|
   <%- if @configs['mock_with'] -%>
   c.mock_with <%= @configs['mock_with'] %>
   <%- end -%>
+  <%- if @configs['hiera_config'] -%>
+  c.hiera_config = <%= @configs['hiera_config'] %>
+  <%- end -%>
 end
 
 <%- [@configs['spec_overrides']].flatten.compact.each do |line| -%>


### PR DESCRIPTION
This adds an option to configure rspec-puppet's `hiera_config` option in
`spec/spec_helper.rb`.  This is useful-- required, even-- for testing
Hiera v4 module data.