### PR TITLE
Add RBENV's .ruby-version file to gitignore

### DIFF
--- a/moduleroot/.gitignore
+++ b/moduleroot/.gitignore
@@ -7,6 +7,7 @@ spec/fixtures/manifests/
 spec/fixtures/modules/
 .vagrant/
 .bundle/
+.ruby-version
 coverage/
 log/
 .idea/


### PR DESCRIPTION
Added the rbenv .ruby-version file to gitignore.