### PR TITLE
bump puppetlabs_spec_helper + add needed dependency

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -17,7 +17,8 @@ Gemfile:
   required:
     ':test':
       - gem: puppetlabs_spec_helper
-        version: '~> 1.2.2'
+        version: '~> 2.0.1'
+      - gem: parallel_tests
       - gem: rspec-puppet
         version: '~> 2.5'
       - gem: rspec-puppet-facts


### PR DESCRIPTION
I tested this locally with puppet-zabbix. Works great so far, spec tests run now in parallel. However we should hold of with merging, puppetlabs_spec_helper seems to be broken in certain situations. https://github.com/puppetlabs/puppetlabs_spec_helper/pull/177