### PR TITLE
fix module publishing

### DIFF
--- a/moduleroot/.pmtignore
+++ b/moduleroot/.pmtignore
@@ -1,1 +1,25 @@
 docs/
+pkg/
+Gemfile.lock
+Gemfile.local
+vendor/
+.vendor/
+spec/fixtures/manifests/
+spec/fixtures/modules/
+.vagrant/
+.bundle/
+.ruby-version
+coverage/
+log/
+.idea/
+.dependencies/
+.librarian/
+Puppetfile.lock
+*.iml
+.*.sw?
+.yardoc/
+<% if ! @configs['paths'].nil? -%>
+<% @configs['paths'].each do |path| -%>
+<%= path %>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
this should fix the module publishing issue in voxpupuli/puppet-proxysql#10

[docs ref](https://docs.puppet.com/puppet/4.8/modules_publishing.html#set-files-to-be-ignored): `.pmtignore` get precedence on `.gitignore`