### PR TITLE
Add augeasproviders_core setup to spec_helper.rb

### DIFF
--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -2,6 +2,20 @@ require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 include RspecPuppetFacts
 
+<% if @configs['augeasproviders'] -%>
+# Setup augeasproviders
+require 'pathname'
+dir = Pathname.new(__FILE__).parent
+$LOAD_PATH.unshift(dir, File.join(dir, 'fixtures/modules/augeasproviders_core/spec/lib'), File.join(dir, '..', 'lib'))
+require 'augeas_spec'
+require 'pathname'
+dir = Pathname.new(__FILE__).parent
+Puppet[:modulepath] = File.join(dir, 'fixtures', 'modules')
+puts 'augeasproviders: setting Puppet[:libdir] to work around broken type autoloading'
+# libdir is only a single dir, so it can only workaround loading of one external module
+Puppet[:libdir] = "#{Puppet[:modulepath]}/augeasproviders_core/lib"
+
+<% end -%>
 if Dir.exist?(File.expand_path('../../lib', __FILE__))
   require 'coveralls'
   require 'simplecov'


### PR DESCRIPTION
Contains various spec helpers and a fix for Puppet's bad loading of the
augeasproviders_core dependency on some versions. Extracted from
puppet-puppetserver.