### PR TITLE
Mask tty's in docker acceptance nodesets

### DIFF
--- a/moduleroot/spec/acceptance/nodesets/docker/centos-7.yml
+++ b/moduleroot/spec/acceptance/nodesets/docker/centos-7.yml
@@ -11,6 +11,7 @@ HOSTS:
     docker_cmd: '["/usr/sbin/init"]'
     docker_image_commands:
       - 'yum install -y crontabs initscripts iproute openssl sysvinit-tools tar wget which ss'
+      - 'systemctl mask getty@tty1.service'
 CONFIG:
   trace_limit: 200
   masterless: true

--- a/moduleroot/spec/acceptance/nodesets/docker/debian-8.yml
+++ b/moduleroot/spec/acceptance/nodesets/docker/debian-8.yml
@@ -13,6 +13,7 @@ HOSTS:
       - 'echo deb http://ftp.debian.org/debian jessie-backports main >> /etc/apt/sources.list'
       - 'apt-get update && apt-get install -y cron locales-all net-tools wget'
       - 'rm -f /usr/sbin/policy-rc.d'
+      - 'systemctl mask getty@tty1.service getty-static.service'
 CONFIG:
   trace_limit: 200
   masterless: true


### PR DESCRIPTION
Since beaker containers are privileged these tty's can interfere with
the system tty's. This can be an unpleasant surprise for those running
on Linux.