### PR TITLE
bump rubocop 0.47.0->0.47.1

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -38,7 +38,7 @@ Gemfile:
         version: '~> 1.0.0'
       - gem: redcarpet
       - gem: rubocop
-        version: '~> 0.47.0'
+        version: '~> 0.47.1'
         ruby-operator: '>='
         ruby-version: '2.3.0'
       - gem: rubocop-rspec


### PR DESCRIPTION
There was a bugfix release that we already use for new installations. We
should ensure that people always use that and bump it. Just in case for
people that have outdated gems laying around.