### PR TITLE
drop parallel_tests + bump puppetlabs_spec_helper

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -17,8 +17,7 @@ Gemfile:
   required:
     ':test':
       - gem: puppetlabs_spec_helper
-        version: '~> 2.1.0'
-      - gem: parallel_tests
+        version: '~> 2.1.1'
       - gem: rspec-puppet
         version: '~> 2.5'
       - gem: rspec-puppet-facts


### PR DESCRIPTION
latest puppetlabs_spec_helper has a dependency for parallel_tests, so we
don't need to specify it.