### PR TITLE
Provide a default overcommit config file

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -63,6 +63,9 @@ Gemfile:
       - gem: travis
       - gem: travis-lint
       - gem: guard-rake
+      - gem: overcommit
+        ruby-operator: '>='
+        ruby-version: '0.39.1'
     ':system_tests':
       - gem: beaker-rspec
       - gem: serverspec

--- a/moduleroot/.overcommit.yml
+++ b/moduleroot/.overcommit.yml
@@ -1,0 +1,63 @@
+# Managed by https://github.com/voxpupuli/modulesync_configs
+#
+# Hooks are only enabled if you take action.
+#
+# To enable the hooks run:
+#
+# ```
+# bundle exec overcommit --install
+# # ensure .overcommit.yml does not harm to you and then
+# bundle exec overcommit --sign
+# ```
+#
+# (it will manage the .git/hooks directory):
+#
+# Examples howto skip a test for a commit or push:
+#
+# ```
+# SKIP=RuboCop git commit
+# SKIP=PuppetLint git commit
+# SKIP=RakeTask git push
+# ```
+#
+# Don't invoke overcommit at all:
+#
+# ```
+# OVERCOMMIT_DISABLE=1 git commit
+# ```
+#
+# Read more about overcommit: https://github.com/brigade/overcommit
+#
+# To manage this config yourself in your module add
+#
+# ```
+# .overcommit.yml:
+#   unmanaged: true
+# ```
+#
+# to your modules .sync.yml config
+---
+PreCommit:
+  RuboCop:
+    enabled: true
+    description: 'Runs rubocop on modified files only'
+    command: ['bundle', 'exec', 'rubocop']
+  PuppetLint:
+    enabled: true
+    description: 'Runs puppet-lint on modified files only'
+    command: ['bundle', 'exec', 'puppet-lint']
+  YamlSyntax:
+    enabled: true
+  JsonSyntax:
+    enabled: true
+  TrailingWhitespace:
+    enabled: true
+
+PrePush:
+  RakeTarget:
+    enabled: true
+    description: 'Run rake targets'
+    targets:
+      - 'test'
+      - 'rubocop'
+    command: [ 'bundle', 'exec', 'rake' ]


### PR DESCRIPTION
Hooks are only enabled if you take action.

To enable the hooks run:

```
bundle install
bundle exec overcommit --install
bundle exec overcommit --sign
```

(it will manage the .git/hooks directory):

Examples howto skip a test for a commit or push:

```
SKIP=RuboCop git commit
SKIP=PuppetLint git commit
SKIP=RakeTask git push
```

Don't invoke overcommit at all:

```
OVERCOMMIT_DISABLE=1 git commit
```

Read more about overcommit: https://github.com/brigade/overcommit

Things to discuss:

* what to run on PrePush (see hook list on github)
* what to run on PrePreCommit (see hook list on github)
* there are also few that are enabled by default (see github overcommit README.md
  - the ones with * prefix in the hook list)
* do we need to exclude some directories by default  (consider: the non-rake
  tasks are only run if a changed file matches an include rule)?
* i thought about making it configureable with .sync.yml but then decided to do
  it when its really required (maybe only few will use this overcommit thing
  because it needs manual action to enable it)