### PR TITLE
Disable rubocop for Gemfile/Rakefile

### DIFF
--- a/moduleroot/.rubocop.yml
+++ b/moduleroot/.rubocop.yml
@@ -9,6 +9,8 @@ AllCops:
     - .vendor/**/*
     - pkg/**/*
     - spec/fixtures/**/*
+    - Gemfile
+    - Rakefile
     <%- if !@configs.nil? and @configs.has_key?('AllCops') and @configs['AllCops'].has_key?('Exclude') -%>
     <%- @configs['AllCops']['Exclude'].each do |x| -%>
     - <%= x %>


### PR DESCRIPTION
we generate both files with modulesync. changing the layout with rubocop
will bring us a cyclic dependency. We need to fix our template
generation before we run rubocop on both files.