### PR TITLE
Ignore Guardfile when doing rubocop checks

### DIFF
--- a/moduleroot/.gitignore
+++ b/moduleroot/.gitignore
@@ -17,6 +17,7 @@ Puppetfile.lock
 *.iml
 .*.sw?
 .yardoc/
+Guardfile
 <% if ! @configs['paths'].nil? -%>
 <% @configs['paths'].each do |path| -%>
 <%= path %>

--- a/moduleroot/.rubocop.yml
+++ b/moduleroot/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
     - spec/fixtures/**/*
     - Gemfile
     - Rakefile
+    - Guardfile
     <%- if !@configs.nil? and @configs.has_key?('AllCops') and @configs['AllCops'].has_key?('Exclude') -%>
     <%- @configs['AllCops']['Exclude'].each do |x| -%>
     - <%= x %>


### PR DESCRIPTION
```Style/FileName: The name of this source file (Guardfile) should use snake_case```
Guardfiles are really a personal preference thing and shouldn't be synced or checked
