### PR TITLE
add locales to the ubuntu16.04 docker image

### DIFF
--- a/moduleroot/spec/acceptance/nodesets/docker/ubuntu-16.04.yml
+++ b/moduleroot/spec/acceptance/nodesets/docker/ubuntu-16.04.yml
@@ -10,7 +10,7 @@ HOSTS:
     docker_preserve_image: true
     docker_cmd: '["/sbin/init"]'
     docker_image_commands:
-      - 'apt-get install -y net-tools wget'
+      - 'apt-get install -y net-tools wget locales'
       - 'locale-gen en_US.UTF-8'
 CONFIG:
   trace_limit: 200


### PR DESCRIPTION
the package got dropped upstream from the default container, so we need
to reinstall it.