### PR TITLE
disable Style/IndentHeredoc

### DIFF
--- a/moduleroot/.rubocop.yml
+++ b/moduleroot/.rubocop.yml
@@ -527,6 +527,10 @@ RSpec/RepeatedDescription:
 RSpec/NestedGroups:
   Enabled: False
 
+# this is broken on ruby1.9
+Style/IndentHeredoc:
+  Enabled: False
+
 # disable Yaml safe_load. This is needed to support ruby2.0.0 development envs
 Security/YAMLLoad:
   Enabled: false


### PR DESCRIPTION
this cop is only useful on newer ruby versions. Proper fixes don't work
on ruby1.9. We still need to support 1.9 because that is used by jruby
in puppetserver.