### PR TITLE
Ignore naming of Guardfile

### DIFF
--- a/moduleroot/.rubocop.yml
+++ b/moduleroot/.rubocop.yml
@@ -534,3 +534,8 @@ Style/IndentHeredoc:
 # disable Yaml safe_load. This is needed to support ruby2.0.0 development envs
 Security/YAMLLoad:
   Enabled: false
+
+# Ignore naming of files with standard filenames
+Style/FileName:
+  Exclude:
+    - Guardfile


### PR DESCRIPTION
    Guardfile:1:1: C: Style/FileName: The name of this source file (Guardfile)
    should use snake_case.  (https://github.com/bbatsov/ruby-style-guide#snake-case-files)