### PR TITLE
add the parallel_tests gem

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -74,6 +74,7 @@ Gemfile:
       - gem: github_changelog_generator
         ruby-operator: '>='
         ruby-version: '2.2.2'
+      - gem: parallel_tests
     ':development':
       - gem: travis
       - gem: travis-lint

--- a/moduleroot/.rspec_parallel.erb
+++ b/moduleroot/.rspec_parallel.erb
@@ -1,0 +1,1 @@
+--format progress


### PR DESCRIPTION
this allows us to run spec tests in parallel. We already enabled this in
our configs in the past, but we didn't include this gem. It was a
dependency of puppetlabs_spec_helper. This got removed so we need to
install it explicitly. Changes tested at:
https://github.com/voxpupuli/puppet-zabbix/blob/master/Gemfile#L39
https://travis-ci.org/voxpupuli/puppet-zabbix/builds/235141105