### PR TITLE
Add Fedora 26 beta nodeset

### DIFF
--- a/moduleroot/spec/acceptance/nodesets/fedora-26-beta-x64.yml
+++ b/moduleroot/spec/acceptance/nodesets/fedora-26-beta-x64.yml
@@ -1,0 +1,18 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
+#
+# platform is fedora 25 because there is no
+# puppet-agent for fedora 26 by 2017-06-14
+HOSTS:
+  fedora-26-beta-x64:
+    roles:
+      - master
+    platform: fedora-25-x86_64
+    box: fedora/beta-26-cloud-base
+    hypervisor: vagrant
+CONFIG:
+  type: aio
+...
+# vim: syntax=yaml


### PR DESCRIPTION
Puppet agent for Fedora 25 seems to work on Fedora 26.

This enables one to test the new release now. The final release
of Fedora 26 is expected in july.

Example how to run run beaker acceptance tests with this nodeset:

```
BEAKER_debug=yes BEAKER_set="fedora-26-beta-x64" \
  PUPPET_INSTALL_TYPE="agent" \
  bundle exec rake beaker
```