### PR TITLE
Remove facter gem pinning

### DIFF
--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -55,7 +55,7 @@ end
 if facterversion = ENV['FACTER_GEM_VERSION']
   gem 'facter', facterversion.to_s, :require => false, :groups => [:test]
 else
-gem 'facter', '~> 2.4.6', :require => false, :groups => [:test]
+gem 'facter', :require => false, :groups => [:test]
 end
 
 ENV['PUPPET_VERSION'].nil? ? puppetversion = '<%= @configs['puppet_version'] || '~> 5.0' %>' : puppetversion = ENV['PUPPET_VERSION'].to_s


### PR DESCRIPTION
facterdb 0.3.12 was recently released with facts for facter 2.5.0 so
the pinning is no longer required.