### PR TITLE
Add apt-transport-https to ubuntu docker nodesets

### DIFF
--- a/moduleroot/spec/acceptance/nodesets/docker/ubuntu-14.04.yml.erb
+++ b/moduleroot/spec/acceptance/nodesets/docker/ubuntu-14.04.yml.erb
@@ -12,7 +12,7 @@ HOSTS:
     docker_image_commands:
       - 'rm /usr/sbin/policy-rc.d'
       - 'rm /sbin/initctl; dpkg-divert --rename --remove /sbin/initctl'
-      - 'apt-get install -y net-tools wget'
+      - 'apt-get install -y net-tools wget apt-transport-https'
       - 'locale-gen en_US.UTF-8'
 CONFIG:
   trace_limit: 200

--- a/moduleroot/spec/acceptance/nodesets/docker/ubuntu-16.04.yml.erb
+++ b/moduleroot/spec/acceptance/nodesets/docker/ubuntu-16.04.yml.erb
@@ -10,7 +10,7 @@ HOSTS:
     docker_preserve_image: true
     docker_cmd: '["/sbin/init"]'
     docker_image_commands:
-      - 'apt-get install -y net-tools wget locales'
+      - 'apt-get install -y net-tools wget locales apt-transport-https'
       - 'locale-gen en_US.UTF-8'
 CONFIG:
   trace_limit: 200


### PR DESCRIPTION
This package enables the usage of 'deb https://foo distro main' lines in
the /etc/apt/sources.list

See https://packages.debian.org/sid/apt-transport-https