### PR TITLE
Add 'wont-fix' to config.exclude_labels

### DIFF
--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -43,7 +43,7 @@ begin
     version = (Blacksmith::Modulefile.new).version
     config.future_release = "v#{version}"
     config.header = "# Change log\n\nAll notable changes to this project will be documented in this file.\nEach new release typically also includes the latest modulesync defaults.\nThese should not impact the functionality of the module."
-    config.exclude_labels = %w{duplicate question invalid wontfix modulesync}
+    config.exclude_labels = %w{duplicate question invalid wontfix wont-fix modulesync}
     config.user = 'voxpupuli'
   end
 rescue LoadError


### PR DESCRIPTION
Not sure if some modules might still have issues with 'wontfix' instead
of 'wont-fix', so I've left it in.