### PR TITLE
Don't set config.future_release for -rc versions

### DIFF
--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -41,7 +41,7 @@ begin
   require 'github_changelog_generator/task'
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     version = (Blacksmith::Modulefile.new).version
-    config.future_release = "v#{version}"
+    config.future_release = "v#{version}" if version =~ /^\d+\.\d+.\d+$/
     config.header = "# Change log\n\nAll notable changes to this project will be documented in this file.\nEach new release typically also includes the latest modulesync defaults.\nThese should not impact the functionality of the module."
     config.exclude_labels = %w{duplicate question invalid wontfix wont-fix modulesync}
     config.user = 'voxpupuli'


### PR DESCRIPTION
It can sometimes be nice to refresh the changelog with unreleased
changes.  When the rake task is run and the version is an `-rc` release
`config.future_release` will no longer be set.