### PR TITLE
run acceptance tests on latest ruby version

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -3,7 +3,7 @@
   docker_sets:
   docker_defaults:
     # values will replace @@SET@@ with the docker_sets' value
-    rvm: 2.1.9
+    rvm: 2.4.1
     sudo: required
     dist: trusty
     services: docker


### PR DESCRIPTION
We currently run all tests on 2.4.1. So this should be the default in
modulesync_config