### PR TITLE
Python doesn't exist on the Ubuntu 16.04 base Docker node

### DIFF
--- a/moduleroot/spec/acceptance/nodesets/docker/ubuntu-16.04.yml.erb
+++ b/moduleroot/spec/acceptance/nodesets/docker/ubuntu-16.04.yml.erb
@@ -10,7 +10,7 @@ HOSTS:
     docker_preserve_image: true
     docker_cmd: '["/sbin/init"]'
     docker_image_commands:
-      - 'apt-get install -y net-tools wget locales apt-transport-https'
+      - 'apt-get install -y net-tools wget locales apt-transport-https python'
       - 'locale-gen en_US.UTF-8'
 CONFIG:
   trace_limit: 200


### PR DESCRIPTION
Since Python 2 is installed on older images (and in the Vagrant images distributed by Puppet), what do we think about having this in our default nodeset? 

If not, I can work around it in https://github.com/voxpupuli/puppet-rabbitmq/pull/617