### PR TITLE
Revert "Python doesn't exist on the Ubuntu 16.04 base Docker node"

### DIFF
--- a/moduleroot/spec/acceptance/nodesets/docker/ubuntu-16.04.yml.erb
+++ b/moduleroot/spec/acceptance/nodesets/docker/ubuntu-16.04.yml.erb
@@ -10,7 +10,7 @@ HOSTS:
     docker_preserve_image: true
     docker_cmd: '["/sbin/init"]'
     docker_image_commands:
-      - 'apt-get install -y net-tools wget locales apt-transport-https python'
+      - 'apt-get install -y net-tools wget locales apt-transport-https'
       - 'locale-gen en_US.UTF-8'
 CONFIG:
   trace_limit: 200


### PR DESCRIPTION
Reverts voxpupuli/modulesync_config#371
@ekohl @bastelfreak I'm Ok with reverting this.

It did seem odd to me that python2 isn't on the Docker image we use but is on the Vagrant image that Puppet ships for acceptance tests (and on the Ubuntu 14.04 images for both Docker and Vagrant), but I'm not sure what the normal  / typical case is for Ubuntu 16.04, and I agree that it might make sense to revert this.