### PR TITLE
Ignore docs/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ build/
 /.yardoc/
 /_yardoc/
 /doc/
+/docs/
 /rdoc/
 
 ## Environment normalisation:

--- a/moduleroot/.gitignore.erb
+++ b/moduleroot/.gitignore.erb
@@ -17,6 +17,7 @@ Puppetfile.lock
 *.iml
 .*.sw?
 .yardoc/
+docs/
 Guardfile
 <% if ! @configs['paths'].nil? -%>
 <% @configs['paths'].each do |path| -%>


### PR DESCRIPTION
Not sure if (m)any modules have a doc directory; also not sure whether we'd check in docs generated by `puppet strings`, or whether we want to ignore these. If  we do want to ignore them, this PR will accomplish that.