### PR TITLE
Re-enable ruby 2.1.9 on Puppet 4 tests

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -10,7 +10,7 @@
     env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=@@SET@@ CHECK=beaker
     bundler_args: --without development
   includes:
-  - rvm: 2.4.1
+  - rvm: 2.1.9
     env: PUPPET_VERSION="~> 4.0" CHECK=test
     bundler_args: --without system_tests development
   - rvm: 2.4.1


### PR DESCRIPTION
As the Puppet 4 puppet-agent package is pre-packaged with ruby
2.1.9, we should be testing against that version of ruby to ensure
that nothing we do breaks compatibility with puppet 4.x from the
puppet-agent package or from the PE installer.