### PR TITLE
Add beaker/module_install_helper

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -78,6 +78,7 @@ Gemfile:
       - gem: beaker-rspec
       - gem: serverspec
       - gem: beaker-puppet_install_helper
+      - gem: beaker-module_install_helper
         require: false
 Rakefile:
   default_disabled_lint_checks:


### PR DESCRIPTION
Any reason not to have beaker/module_install_helper by default? It really simplifies spec_helper_acceptance