### PR TITLE
Improve coveralls reporting

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -14,7 +14,7 @@
     env: PUPPET_VERSION="~> 4.0" CHECK=test
     bundler_args: --without system_tests development
   - rvm: 2.4.1
-    env: PUPPET_VERSION="~> 5.0" CHECK=test
+    env: PUPPET_VERSION="~> 5.0" CHECK=test_with_coveralls
     bundler_args: --without system_tests development
   - rvm: 2.4.1
     env: PUPPET_VERSION="~> 5.0" CHECK=rubocop

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -37,6 +37,17 @@ task test: [
 <% end -%>
 ]
 
+desc "Run main 'test' task and report merged results to coveralls"
+task test_with_coveralls: [:test] do
+  if Dir.exist?(File.expand_path('../lib', __FILE__))
+    require 'coveralls/rake/task'
+    Coveralls::RakeTask.new
+    Rake::Task['coveralls:push'].invoke
+  else
+    puts 'Skipping reporting to coveralls.  Module has no lib dir'
+  end
+end
+
 begin
   require 'github_changelog_generator/task'
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -22,8 +22,7 @@ if Dir.exist?(File.expand_path('../../lib', __FILE__))
   require 'simplecov-console'
   SimpleCov.formatters = [
     SimpleCov::Formatter::HTMLFormatter,
-    SimpleCov::Formatter::Console,
-    Coveralls::SimpleCov::Formatter
+    SimpleCov::Formatter::Console
   ]
   SimpleCov.start do
     track_files 'lib/**/*.rb'


### PR DESCRIPTION
Solves 2 issues.

We use parallel_tests, so we should wait for simplecov to merge
results before reporting to coveralls.

We are reporting in two jobs, (once for puppet 4 and again for
puppet 5).

See:
https://coveralls.zendesk.com/hc/en-us/articles/201769485-Ruby-Rails
https://github.com/colszowka/simplecov#merging-results