### PR TITLE
Ignore Vagrantfile

### DIFF
--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -12,6 +12,7 @@ AllCops:
     - Gemfile
     - Rakefile
     - Guardfile
+    - Vagrantfile
     <%- if !@configs.nil? and @configs.has_key?('AllCops') and @configs['AllCops'].has_key?('Exclude') -%>
     <%- @configs['AllCops']['Exclude'].each do |x| -%>
     - <%= x %>


### PR DESCRIPTION
Not sure if we should have Vagrantfiles in modules (one or two do), but having one seems to trigger this rule:
https://github.com/bbatsov/ruby-style-guide#snake-case-files
Since Rakefile and similar files are in our excludes, should Vagrantfile be blanket excluded? Or should / can we just disable this specific check for it?