### PR TITLE
puppet-iis is deprecated; don't manage it

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -29,7 +29,6 @@
 - puppet-healthcheck
 - puppet-hiera
 - puppet-homeassistant
-- puppet-iis
 - puppet-jenkins_job_builder
 - puppet-jira
 - puppet-jolokia


### PR DESCRIPTION
This should be taken out, I believe