### PR TITLE
Disable EndOfLine Rubocop Rule

### DIFF
--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -51,6 +51,9 @@ Style/HashSyntax:
 Style/RedundantReturn:
   Enabled: True
 
+Style/EndOfLine:
+  Enabled: False
+
 Lint/AmbiguousOperator:
   Enabled: True
 


### PR DESCRIPTION
I'm currently trying to add a windows only module to voxpupuli.  It got migrated over but i was wanting to get it running under some CI server.  I initially tried travis but it looks as though rspec-puppet currently doesn't handle running rspec-puppet tests for a windows module ( based on the code it's using ) under a non-windows machine which resulted in this.  https://github.com/voxpupuli/puppet-stackify/pull/8 . This means i need to use appveyor so i began adding the same appveyor from the pdk.  Now i'm getting a rubocop violation because of a rule expecting the file to contain CRLF's in it.  This PR disables this rule, which i feel should also be done here since it's also done in the PDK repo to solve the same issue. https://github.com/puppetlabs/pdk-module-template/blob/a97760dbd35bb6f92c03111485a0eedb21d42a54/config_defaults.yml\#L110-L111