### PR TITLE
Remove backports from apt sources in Debian 7-8 nodesets

### DIFF
--- a/moduleroot/spec/acceptance/nodesets/docker/debian-7.yml.erb
+++ b/moduleroot/spec/acceptance/nodesets/docker/debian-7.yml.erb
@@ -10,7 +10,6 @@ HOSTS:
     docker_preserve_image: true
     docker_cmd: '["/sbin/init"]'
     docker_image_commands:
-      - 'echo deb http://ftp.debian.org/debian wheezy-backports main >> /etc/apt/sources.list'
       - 'apt-get update && apt-get install -y cron locales-all net-tools wget'
 CONFIG:
   trace_limit: 200

--- a/moduleroot/spec/acceptance/nodesets/docker/debian-8.yml.erb
+++ b/moduleroot/spec/acceptance/nodesets/docker/debian-8.yml.erb
@@ -10,7 +10,6 @@ HOSTS:
     docker_preserve_image: true
     docker_cmd: '["/sbin/init"]'
     docker_image_commands:
-      - 'echo deb http://ftp.debian.org/debian jessie-backports main >> /etc/apt/sources.list'
       - 'apt-get update && apt-get install -y cron locales-all net-tools wget'
       - 'rm -f /usr/sbin/policy-rc.d'
       - 'systemctl mask getty@tty1.service getty-static.service'


### PR DESCRIPTION
This removes backports from the apt sources.list for Debian 7-8. We should probably double-check in corosync module, but I don't think it's necessary to bootstrap Puppet, and it also doesn't seem to be done for the Vagrant acceptance test, so this creates some inconsistency.

I think when this needs to be configured, it should be handled as a soft dep in the module's README, and possibly added to `spec_helper_acceptance`