### PR TITLE
requires at least beaker 3.9.0

### DIFF
--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -37,6 +37,8 @@ group <%= group %> do
 <% if gem['gem'] == 'beaker-rspec' -%>
   if beaker_version = ENV['BEAKER_VERSION']
     gem 'beaker', *location_for(beaker_version)
+  else
+    gem' beaker', '>= 3.9.0', :require => false
   end
   if beaker_rspec_version = ENV['BEAKER_RSPEC_VERSION']
     gem 'beaker-rspec', *location_for(beaker_rspec_version)


### PR DESCRIPTION
We need to ensure that we get at least beaker 3.9.0. This is the first
release with debian stretch support.