### PR TITLE
notify on all builds

### DIFF
--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -76,7 +76,7 @@ branches:
 notifications:
   email: false
   irc:
-    on_success: change
+    on_success: always
     on_failure: always
     channels:
       - "chat.freenode.org#voxpupuli-notifications"


### PR DESCRIPTION
I got requested that we send out a notification for all successful
builds, not only those that switch from failing to working.