### PR TITLE
add PARALLEL_TEST_PROCESSORS=16 for puppet4

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -11,7 +11,7 @@
     bundler_args: --without development release
   includes:
   - rvm: 2.1.9
-    env: PUPPET_VERSION="~> 4.0" CHECK=test
+    env: PUPPET_VERSION="~> 4.0" CHECK=test PARALLEL_TEST_PROCESSORS=16
     bundler_args: --without system_tests development release
   - rvm: 2.4.2
     env: PUPPET_VERSION="~> 5.0" CHECK=test_with_coveralls


### PR DESCRIPTION
we noticed many failed tests with too many parallel tests. One example
is the collectd module. Travis kills jobs that consume too much CPU
power. We were unable to reproduce this with Puppet5, so we only add it
for puppet4.