### PR TITLE
Update Fedora 25, 26 and add Fedora 27 nodeset

### DIFF
--- a/moduleroot/spec/acceptance/nodesets/fedora-25-x64.yml.erb
+++ b/moduleroot/spec/acceptance/nodesets/fedora-25-x64.yml.erb
@@ -3,8 +3,6 @@
 # https://github.com/voxpupuli/modulesync
 # https://github.com/voxpupuli/modulesync_config
 #
-# platform is fedora 24 because there is no
-# puppet-agent for fedora 25 by 2016-12-30
 HOSTS:
   fedora-25-x64:
     roles:

--- a/moduleroot/spec/acceptance/nodesets/fedora-26-x64.yml.erb
+++ b/moduleroot/spec/acceptance/nodesets/fedora-26-x64.yml.erb
@@ -3,13 +3,11 @@
 # https://github.com/voxpupuli/modulesync
 # https://github.com/voxpupuli/modulesync_config
 #
-# platform is fedora 25 because there is no
-# puppet-agent for fedora 26 by 2017-08-09
 HOSTS:
   fedora-26-x64:
     roles:
       - master
-    platform: fedora-25-x86_64
+    platform: fedora-26-x86_64
     box: fedora/26-cloud-base
     hypervisor: vagrant
 CONFIG:

--- a/moduleroot/spec/acceptance/nodesets/fedora-27-x64.yml.erb
+++ b/moduleroot/spec/acceptance/nodesets/fedora-27-x64.yml.erb
@@ -3,14 +3,14 @@
 # https://github.com/voxpupuli/modulesync
 # https://github.com/voxpupuli/modulesync_config
 #
-# platform is fedora 25 because there is no
-# puppet-agent for fedora 26 by 2017-06-14
+# platform is fedora 26 because there is no puppet-agent
+# for fedora 27 as of 2017-11-17
 HOSTS:
-  fedora-26-beta-x64:
+  fedora-27-x64:
     roles:
       - master
-    platform: fedora-25-x86_64
-    box: fedora/beta-26-cloud-base
+    platform: fedora-26-x86_64
+    box: fedora/27-cloud-base
     hypervisor: vagrant
 CONFIG:
   type: aio


### PR DESCRIPTION
... and the Fedora 26-beta nodeset is removed.