### PR TITLE
s/puppet-windows-env/puppet-windows_env/

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -76,7 +76,7 @@
 - puppet-unattended_upgrades
 - puppet-virtualbox
 - puppet-visualstudio
-- puppet-windows-env
+- puppet-windows_env
 - puppet-windows_autoupdate
 - puppet-windows_eventlog
 - puppet-windows_firewall


### PR DESCRIPTION
puppet-windows_env was the official module name. The repo name needs to
be the same, otherwise this breaks our automation