### PR TITLE
Handle missing keys in rake beaker_sets

### DIFF
--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -66,8 +66,8 @@ task 'beaker_sets', [:directory] do |t, args|
 
   metadata = JSON.load(File.read('metadata.json'))
 
-  metadata['operatingsystem_support'].each do |os|
-    os['operatingsystemrelease'].each do |release|
+  (metadata['operatingsystem_support'] || []).each do |os|
+    (os['operatingsystemrelease'] || []).each do |release|
       if directory
         beaker_set = "#{directory}/#{os['operatingsystem'].downcase}-#{release}"
       else


### PR DESCRIPTION
With this I was able to easily create PRs for all the supported operating systems where we run beaker tests:

* [ ] https://github.com/voxpupuli/puppet-autofs/pull/85
* [ ] https://github.com/voxpupuli/puppet-collectd/pull/732
* [ ] https://github.com/voxpupuli/puppet-corosync/pull/426
* [ ] https://github.com/voxpupuli/puppet-gluster/pull/144
* [ ] https://github.com/voxpupuli/puppet-nscd/pull/24
* [x] https://github.com/voxpupuli/puppet-report_hipchat/pull/32
* [x] https://github.com/voxpupuli/puppet-yum/pull/79