### PR TITLE
Fix Rubocop namespace for EndOfLine

### DIFF
--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -51,7 +51,7 @@ Style/HashSyntax:
 Style/RedundantReturn:
   Enabled: True
 
-Style/EndOfLine:
+Layout/EndOfLine:
   Enabled: False
 
 Lint/AmbiguousOperator:


### PR DESCRIPTION
As shown by running Rubocop, Style/EndOfLine should be Layout/EndOfLine