### PR TITLE
fetch changelog generator from git

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -71,6 +71,7 @@ Gemfile:
         require: false
     ':release':
       - gem: github_changelog_generator
+        git: https://github.com/skywinder/github-changelog-generator
         ruby-operator: '>='
         ruby-version: '2.2.2'
       - gem: puppet-blacksmith


### PR DESCRIPTION
this will fetch the latest tag. It was created in october, we need it,
but it isn't released as gem...