### PR TITLE
mask the tty service on ubuntu16.04 docker

### DIFF
--- a/moduleroot/spec/acceptance/nodesets/docker/ubuntu-16.04.yml.erb
+++ b/moduleroot/spec/acceptance/nodesets/docker/ubuntu-16.04.yml.erb
@@ -10,6 +10,7 @@ HOSTS:
     docker_preserve_image: true
     docker_cmd: '["/sbin/init"]'
     docker_image_commands:
+      - 'systemctl mask getty@tty1.service getty-static.service'
       - 'apt-get install -y net-tools wget locales apt-transport-https'
       - 'locale-gen en_US.UTF-8'
 CONFIG:


### PR DESCRIPTION
if the host is running a modern version of systemd + Xorg, the tty in the
container will conflict with the one on the host. Then the Xorg will be
killed and the ttys in the container will overwrite the ones from the
host => you see the tty from the container on you local workstation: https://p.bastelfreak.de/oxSNt/