### PR TITLE
Configure the default locale on ubuntu16.04 docker

### DIFF
--- a/moduleroot/spec/acceptance/nodesets/docker/ubuntu-16.04.yml.erb
+++ b/moduleroot/spec/acceptance/nodesets/docker/ubuntu-16.04.yml.erb
@@ -12,6 +12,7 @@ HOSTS:
     docker_image_commands:
       - 'apt-get install -y net-tools wget locales apt-transport-https'
       - 'locale-gen en_US.UTF-8'
+      - 'echo LANG=en_US.UTF-8 > /etc/default/locale'
 CONFIG:
   trace_limit: 200
   masterless: true


### PR DESCRIPTION
without this, we may get the following error during puppets exec
resources: Error: invalid byte sequence in US-ASCII puppet