### PR TITLE
Pin mocha version to ~> 1.4.0 for now

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -51,7 +51,7 @@ Gemfile:
         ruby-operator: '>='
         ruby-version: '2.3.0'
       - gem: mocha
-        version: '>= 1.2.1'
+        version: '~> 1.4.0'
       - gem: coveralls
       - gem: simplecov-console
       - gem: rack


### PR DESCRIPTION
It seems like 1.5.0 creates some breaking changes, so we should probably pin the default to 1.4.x until we get a handle on this? Let me know if the version specification should be a range instead.