### PR TITLE
Ensure clean continues

### DIFF
--- a/bin/clean-git-checkouts
+++ b/bin/clean-git-checkouts
@@ -6,9 +6,9 @@ for module in modules/* ; do
   (cd $module
   git status
   git reset --hard
-  git clean -fx
+  git clean -dfx
   git checkout master
   git pull --prune
-  git branch -D modulesync
+  git branch -D modulesync || true
   )
 done


### PR DESCRIPTION
df9534326d0b6f4c8e5da85aa40c5f0f514c2be6 changed this script to exit on
errors. A branch deletion also fails if the branch doesnt exist so
rerunning the script fails. This patch ensures it continues.