### PR TITLE
dont enforce a version of puppetlabs_spec_helper

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -29,7 +29,7 @@ Gemfile:
   required:
     ':test':
       - gem: puppetlabs_spec_helper
-        version: '~> 2.6.0'
+        version: '~> 2.6'
       - gem: rspec-puppet
         version: '~> 2.5'
       - gem: rspec-puppet-facts


### PR DESCRIPTION
This was needed ages ago to don't use a legacy version that was broken for us. It now get regular updates and it doesn't make sense to update the version in our Gemfile every time.