### PR TITLE
implement gems to ssh into (remote) docker nodes

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -74,6 +74,14 @@ Gemfile:
       - gem: beaker-puppet_install_helper
       - gem: beaker-module_install_helper
         require: false
+      - gem: rbnacl
+        version: '~> 4'
+        ruby-operator: '>='
+        ruby-version: '2.2.6'
+      - gem: rbnacl-libsodium
+        ruby-operator: '>='
+        ruby-version: '2.2.6'
+      - gem: bcrypt_pbkdf
     ':release':
       - gem: github_changelog_generator
         git: https://github.com/skywinder/github-changelog-generator


### PR DESCRIPTION
beaker-docker uses net-ssh to ssh into (remote) docker ndoes. Modern
ed-25519 keys are supported, but they require three additional gems.
More background information is available at: https://github.com/net-ssh/net-ssh/issues/478