### PR TITLE
unpin puppet-strings

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -91,7 +91,7 @@ Gemfile:
       - gem: voxpupuli-release
         git: https://github.com/voxpupuli/voxpupuli-release-gem
       - gem: puppet-strings
-        version: '~> 1.0'
+        version: '>= 1.0'
 Rakefile:
   default_disabled_lint_checks:
   - 'relative'


### PR DESCRIPTION
there is no reason to pin this. Months ago there were some issues with a
0.9 release wich we didn't want to pull in. Now 2.1.0 got released and
works without issues.