### PR TITLE
add puppet-gitlab-ci-runner to managed modules

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -29,6 +29,7 @@
 - puppet-ghost
 - puppet-git_resource
 - puppet-gitlab
+- puppet-gitlab-ci-runner
 - puppet-gluster
 - puppet-googleauthenticator
 - puppet-grafana


### PR DESCRIPTION
This adds [voxpupuli/puppet-gitlab-ci-runner](https://github.com/voxpupuli/puppet-gitlab-ci-runner) to the managed modules list.

This goes with [puppet-gitlab-ci-runner PR#1](https://github.com/voxpupuli/puppet-gitlab-ci-runner/pull/1) (Setting up modulesync for the module). These PR's should be accepted together.