### PR TITLE
update module name for gitlab_ci_runner

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -29,7 +29,7 @@
 - puppet-ghost
 - puppet-git_resource
 - puppet-gitlab
-- puppet-gitlab-ci-runner
+- puppet-gitlab_ci_runner
 - puppet-gluster
 - puppet-googleauthenticator
 - puppet-grafana


### PR DESCRIPTION
corrects puppet-gitlab-ci-runner to `puppet-gitlab_ci_runner`. The `-` character isn't allowed in class names.