### PR TITLE
puppet6 is released, use it with acceptance tests

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -13,6 +13,12 @@
     sudo: required
     dist: trusty
     services: docker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=@@SET@@{hypervisor=docker} CHECK=beaker
+    bundler_args: --without development release
+  - rvm: 2.5.1
+    sudo: required
+    dist: trusty
+    services: docker
     env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6-nightly BEAKER_debug=true BEAKER_setfile=@@SET@@{hypervisor=docker} CHECK=beaker
     bundler_args: --without development release
   includes:


### PR DESCRIPTION
Now puppet6 is realsed it is better to not use nightly as default.