### PR TITLE
Remove redundant default facts

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -43,6 +43,7 @@ Gemfile:
       - gem: puppetlabs_spec_helper
         version: '>= 2.11.0'
       - gem: rspec-puppet-facts
+        version: '>= 1.8.0'
       - gem: rspec-puppet-utils
       - gem: puppet-lint-leading_zero-check
       - gem: puppet-lint-trailing_comma-check

--- a/moduleroot/spec/default_facts.yml.erb
+++ b/moduleroot/spec/default_facts.yml.erb
@@ -8,7 +8,6 @@
 # Hint if using with rspec-puppet-facts ("on_supported_os.each"):
 #   if a same named fact exists in facterdb it will be overridden.
 ---
-concat_basedir: "/tmp"
 ipaddress: "172.16.254.254"
 is_pe: false
 macaddress: "AA:AA:AA:AA:AA:AA"

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -37,10 +37,7 @@ if Dir.exist?(File.expand_path('../../lib', __FILE__))
 end
 
 RSpec.configure do |c|
-  default_facts = {
-    puppetversion: Puppet.version,
-    facterversion: Facter.version
-  }
+  default_facts = {}
   default_facts.merge!(YAML.load(File.read(File.expand_path('../default_facts.yml', __FILE__)))) if File.exist?(File.expand_path('../default_facts.yml', __FILE__))
   default_facts.merge!(YAML.load(File.read(File.expand_path('../default_module_facts.yml', __FILE__)))) if File.exist?(File.expand_path('../default_module_facts.yml', __FILE__))
   c.default_facts = default_facts


### PR DESCRIPTION
Since rspec-puppet-facts 1.1.0 puppetversion is set. The facter version is set since 1.8.0.

The concat_basedir fact isn't used since puppetlabs-concat 2.0.