### PR TITLE
Update metadata cleaning script

### DIFF
--- a/bin/clean-metadata
+++ b/bin/clean-metadata
@@ -3,7 +3,7 @@ import os
 import json
 
 # Note range is exclusive so the last number is not in the list
-PUPPET_VERSION = '>= 4.10.0 < 6.0.0'
+PUPPET_VERSION = '>= 4.10.0 < 7.0.0'
 UNSUPPORTED_EL = {str(i) for i in range(3, 6)}
 UNSUPPORTED = {
     'CentOS': UNSUPPORTED_EL,
@@ -14,7 +14,7 @@ UNSUPPORTED = {
     'SLED': {'9', '10'},
     'SLES': {'9', '10'},
     'Scientific': UNSUPPORTED_EL,
-    'Ubuntu': {str(i) + m for i in range(4, 17) for m in ('.04', '.10')} - {'14.04', '16.04'},
+    'Ubuntu': {str(i) + m for i in range(4, 18) for m in ('.04', '.10')} - {'14.04', '16.04'},
 }
 
 for mod in os.listdir('modules'):


### PR DESCRIPTION
We should now ensure Puppet 6 is allowed. Also we have some new Ubuntu versions.