### PR TITLE
Add Dockerfile for local tests

### DIFF
--- a/moduleroot/.github/CONTRIBUTING.md.erb
+++ b/moduleroot/.github/CONTRIBUTING.md.erb
@@ -109,6 +109,21 @@ To run a specific spec test set the `SPEC` variable:
 bundle exec rake spec SPEC=spec/foo_spec.rb
 ```
 
+### Unit tests in docker
+
+Some people don't want to run the dependencies locally or don't want to install
+ruby. We ship a Dockerfile that enables you to run all unit tests and linting.
+You only need to run:
+
+```sh
+docker build .
+```
+
+Please ensure that a docker daemon is running and that your user has the
+permission to talk to it. You can specify a remote docker host by setting the
+`DOCKER_HOST` environment variable. it will copy the content of the module into
+the docker image. So it will not work if a Gemfile.lock exists.
+
 ## Integration tests
 
 The unit tests just check the code runs, not that it does exactly what

--- a/moduleroot/.pmtignore.erb
+++ b/moduleroot/.pmtignore.erb
@@ -18,6 +18,7 @@ Puppetfile.lock
 *.iml
 .*.sw?
 .yardoc/
+Dockerfile
 <% if ! @configs['paths'].nil? -%>
 <% @configs['paths'].each do |path| -%>
 <%= path %>

--- a/moduleroot/Dockerfile
+++ b/moduleroot/Dockerfile
@@ -1,0 +1,21 @@
+FROM ruby:2.5.1
+
+WORKDIR /opt/puppet
+
+# https://github.com/puppetlabs/puppet/blob/06ad255754a38f22fb3a22c7c4f1e2ce453d01cb/lib/puppet/provider/service/runit.rb#L39
+RUN mkdir -p /etc/sv
+
+ARG PUPPET_VERSION="~> 6.0"
+ARG PARALLEL_TEST_PROCESSORS=4
+
+# Cache gems
+COPY Gemfile .
+RUN bundle install --without system_tests development release --path=${BUNDLE_PATH:-vendor/bundle}
+
+COPY . .
+
+RUN bundle install
+RUN bundle exec release_checks
+
+# Container should not saved
+RUN exit 1


### PR DESCRIPTION
Running rspec tests without setup a local environment. 

Just run `docker build .` on the root from the module to see the test results.