### PR TITLE
Remove spec/classes/coverage_spec.rb

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -122,6 +122,8 @@ Rakefile:
   default_enabled_rake_targets:
   - 'metadata_lint'
   - 'release_checks'
+spec/classes/coverage_spec.rb:
+  delete: true
 spec/acceptance/nodesets/centos-6-x64.yml:
   delete: true
 spec/acceptance/nodesets/centos-66-x64-pe.yml:


### PR DESCRIPTION
Since f8107630016e5353eee4da206120b86c33e0d915 we handle this in the spec helper since that works properly with parallel_spec. It didn't enforce removal of the now redundant coverage_spec.rb file.