### PR TITLE
Use BEAKER_HYPERVISOR env var

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -7,19 +7,19 @@
     sudo: required
     dist: trusty
     services: docker
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=@@SET@@{hypervisor=docker} CHECK=beaker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=@@SET@@ BEAKER_HYPERVISOR=docker CHECK=beaker
     bundler_args: --without development release
   - rvm: 2.5.1
     sudo: required
     dist: trusty
     services: docker
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=@@SET@@{hypervisor=docker} CHECK=beaker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=@@SET@@ BEAKER_HYPERVISOR=docker CHECK=beaker
     bundler_args: --without development release
   - rvm: 2.5.1
     sudo: required
     dist: trusty
     services: docker
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6-nightly BEAKER_debug=true BEAKER_setfile=@@SET@@{hypervisor=docker} CHECK=beaker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6-nightly BEAKER_debug=true BEAKER_setfile=@@SET@@ BEAKER_HYPERVISOR=docker CHECK=beaker
     bundler_args: --without development release
   includes:
   - rvm: 2.1.9

--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -38,7 +38,7 @@ group <%= group %> do
   if beaker_version = ENV['BEAKER_VERSION']
     gem 'beaker', *location_for(beaker_version)
   else
-    gem 'beaker', '>= 3.9.0', :require => false
+    gem 'beaker', '>= 4.2.0', :require => false
   end
   if beaker_rspec_version = ENV['BEAKER_RSPEC_VERSION']
     gem 'beaker-rspec', *location_for(beaker_rspec_version)


### PR DESCRIPTION
Beaker 4.2.0 allows specifying the hypervisor explicitly via an env var.  This means we can simplify the setfile and allow complex definitions via .sync.yml