### PR TITLE
drop Puppet 4 tests

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -22,9 +22,6 @@
     env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6-nightly BEAKER_debug=true BEAKER_setfile=@@SET@@ BEAKER_HYPERVISOR=docker CHECK=beaker
     bundler_args: --without development release
   includes:
-  - rvm: 2.1.9
-    env: PUPPET_VERSION="~> 4.0" CHECK=test PARALLEL_TEST_PROCESSORS=12
-    bundler_args: --without system_tests development release
   - rvm: 2.4.4
     env: PUPPET_VERSION="~> 5.0" CHECK=test
     bundler_args: --without system_tests development release


### PR DESCRIPTION
Puppet 4 is EOL by the end of 2018.