### PR TITLE
prefix travis script with sh

### DIFF
--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -21,7 +21,7 @@ addons:
   <%- end -%>
 <%- end -%>
 before_install:
-  - ./.travis/setup.sh
+  - sh ./.travis/setup.sh
 script:
   - 'bundle exec rake $CHECK'
 matrix:


### PR DESCRIPTION
msync doesn't set the +x bit, so a simple `./..` does not work. We now
prefix the script with `sh` and everything is fine again.