### PR TITLE
(GH-151) Implement whitespace checks for markdown

### DIFF
--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -49,6 +49,22 @@ task test: [
 <% end -%>
 ]
 
+namespace :check do
+  desc 'Check for trailing whitespace'
+  task :trailing_whitespace do
+    Dir.glob('**/*.md', File::FNM_DOTMATCH).sort.each do |filename|
+      next if filename =~ %r{^((modules|acceptance|\.?vendor|spec/fixtures|pkg)/|REFERENCE.md)}
+      File.foreach(filename).each_with_index do |line, index|
+        if line =~ %r{\s\n$}
+          puts "#{filename} has trailing whitespace on line #{index + 1}"
+          exit 1
+        end
+      end
+    end
+  end
+end
+Rake::Task[:release_checks].enhance ['check:trailing_whitespace']
+
 desc "Run main 'test' task and report merged results to coveralls"
 task test_with_coveralls: [:test] do
   if Dir.exist?(File.expand_path('../lib', __FILE__))


### PR DESCRIPTION
This implements a rake task check:trailing_whitespace. The actual check has mostly been written by Garrett Honeycutt.

Co-authored-by: Garrett Honeycutt <code@garretthoneycutt.com>