### PR TITLE
Remove duplicate metadata_lint check

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -114,7 +114,6 @@ Rakefile:
   - 'disable_documentation'
   - 'disable_single_quote_string_with_variables'
   default_enabled_rake_targets:
-  - 'metadata_lint'
   - 'release_checks'
 spec/default_facts.yml:
   delete: true


### PR DESCRIPTION
Since puppetlabs_spec_helper 1.1.0 this has been part of the validate task. Validate is part of release_checks.

It's also possible to fully remove this mechanism since no module appears to be using it. We can just standardize on release_checks instead of our custom task test but I chose the simple way here.