### PR TITLE
Add a reference task to generate REFERENCE.md

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -39,7 +39,7 @@ Gemfile:
   required:
     ':test':
       - gem: puppetlabs_spec_helper
-        version: '>= 2.11.0'
+        version: '>= 2.14.0'
       - gem: rspec-puppet-facts
         version: '>= 1.8.0'
       - gem: rspec-puppet-utils

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -90,7 +90,7 @@ Gemfile:
       - gem: voxpupuli-release
         git: https://github.com/voxpupuli/voxpupuli-release-gem
       - gem: puppet-strings
-        version: '>= 1.0'
+        version: '>= 2.2'
 Rakefile:
   config.user: voxpupuli
   default_disabled_lint_checks:
@@ -101,6 +101,7 @@ Rakefile:
   - 'disable_single_quote_string_with_variables'
   default_enabled_rake_targets:
   - 'release_checks'
+  puppet_strings_patterns: []
 spec/default_facts.yml:
   delete: true
 spec/classes/coverage_spec.rb:

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -96,6 +96,12 @@ task 'beaker_sets', [:directory] do |t, args|
   end
 end
 
+desc 'Generate REFERENCE.md'
+task :reference, [:debug, :backtrace] do |t, args|
+  patterns = '<%= @configs['puppet_strings_patterns'].join(" ") %>'
+  Rake::Task['strings:generate:reference'].invoke(patterns, args[:debug], args[:backtrace])
+end
+
 begin
   require 'github_changelog_generator/task'
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -3,9 +3,7 @@ require 'puppetlabs_spec_helper/rake_tasks'
 # load optional tasks for releases
 # only available if gem group releases is installed
 begin
-  require 'puppet_blacksmith/rake_tasks'
   require 'voxpupuli/release/rake_tasks'
-  require 'puppet-strings/tasks'
 rescue LoadError
 end
 


### PR DESCRIPTION
In puppet-extlib we can now set:

```yaml
Rakefile:
  puppet_strings_patterns: lib/puppet/functions/extlib/*.rb
```