### PR TITLE
Set lowest supported Puppet version 4.10.0->5.5.8

### DIFF
--- a/bin/clean-metadata
+++ b/bin/clean-metadata
@@ -3,7 +3,7 @@ import os
 import json
 
 # Note range is exclusive so the last number is not in the list
-PUPPET_VERSION = '>= 4.10.0 < 7.0.0'
+PUPPET_VERSION = '>= 5.5.8 < 7.0.0'
 UNSUPPORTED_EL = {str(i) for i in range(3, 6)}
 UNSUPPORTED = {
     'CentOS': UNSUPPORTED_EL,

--- a/bin/get_all_the_diffs
+++ b/bin/get_all_the_diffs
@@ -13,7 +13,7 @@ require 'octokit'
 LEGACY_OR_BROKEN_NOBODY_KNOWS = ['puppet-bacula', 'puppet-nagios_providers', 'puppet-iis', 'puppet-syntax', 'puppet-blacksmith', 'puppet-mode']
 
 # define some versions that we want to match against
-PUPPET_SUPPORT_RANGE = '>= 4.10.0 < 7.0.0'
+PUPPET_SUPPORT_RANGE = '>= 5.5.8 < 7.0.0'
 # Ubuntu 18.04 got released, but Puppet doesn't work yet on it
 # https://tickets.puppetlabs.com/browse/PA-1869
 # https://github.com/camptocamp/facterdb/pull/82#event-1600066178


### PR DESCRIPTION
This is based on https://voxpupuli.org/blog/2019/01/03/dropping-puppet4/