### PR TITLE
Make parameters config.user / user configurable

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -28,6 +28,7 @@
   - rvm: 2.4.4
     env: PUPPET_VERSION="~> 5.0" CHECK=build DEPLOY_TO_FORGE=yes
     bundler_args: --without system_tests development release
+  user: puppet
 Gemfile:
   required:
     ':test':
@@ -85,6 +86,7 @@ Gemfile:
       - gem: puppet-strings
         version: '>= 1.0'
 Rakefile:
+  config.user: voxpupuli
   default_disabled_lint_checks:
   - 'relative'
   - 'disable_140chars'

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -80,7 +80,7 @@ notifications:
       - "chat.freenode.org#voxpupuli-notifications"
 deploy:
   provider: puppetforge
-  user: puppet
+  user: <%= @configs['user'] %>
   password:
     secure: "<%= @configs['secure'] -%>"
   on:

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -105,11 +105,7 @@ begin
     config.future_release = "v#{version}" if version =~ /^\d+\.\d+.\d+$/
     config.header = "# Changelog\n\nAll notable changes to this project will be documented in this file.\nEach new release typically also includes the latest modulesync defaults.\nThese should not affect the functionality of the module."
     config.exclude_labels = %w{duplicate question invalid wontfix wont-fix modulesync skip-changelog}
-<% if ! @configs['config.user'].nil? -%>
     config.user = '<%= @configs['config.user'] -%>'
-<% else -%>
-    config.user = 'voxpupuli'
-<% end -%>
     metadata_json = File.join(File.dirname(__FILE__), 'metadata.json')
     metadata = JSON.load(File.read(metadata_json))
     config.project = metadata['name']

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -105,7 +105,11 @@ begin
     config.future_release = "v#{version}" if version =~ /^\d+\.\d+.\d+$/
     config.header = "# Changelog\n\nAll notable changes to this project will be documented in this file.\nEach new release typically also includes the latest modulesync defaults.\nThese should not affect the functionality of the module."
     config.exclude_labels = %w{duplicate question invalid wontfix wont-fix modulesync skip-changelog}
+<% if ! @configs['config.user'].nil? -%>
+    config.user = '<%= @configs['config.user'] -%>'
+<% else -%>
     config.user = 'voxpupuli'
+<% end -%>
     metadata_json = File.join(File.dirname(__FILE__), 'metadata.json')
     metadata = JSON.load(File.read(metadata_json))
     config.project = metadata['name']


### PR DESCRIPTION
This should not be a static value to make sure that other projects can use msync.