### PR TITLE
Make parameter user configurable

### DIFF
--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -80,7 +80,11 @@ notifications:
       - "chat.freenode.org#voxpupuli-notifications"
 deploy:
   provider: puppetforge
+<% if ! @configs['user'].nil? -%>
+  user: <%= @configs['user'] %>
+<% else -%>
   user: puppet
+<% end -%>
   password:
     secure: "<%= @configs['secure'] -%>"
   on:


### PR DESCRIPTION
This should not be a static value to make sure that other projects can use msync.