### PR TITLE
Make notifications configurable

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -28,6 +28,12 @@
   - rvm: 2.4.4
     env: PUPPET_VERSION="~> 5.0" CHECK=build DEPLOY_TO_FORGE=yes
     bundler_args: --without system_tests development release
+  email: false
+  irc:
+    on_success: always
+    on_failure: always
+    channels:
+    - "chat.freenode.org#voxpupuli-notifications"
   user: puppet
 Gemfile:
   required:

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -72,12 +72,16 @@ branches:
   - master
   - /^v\d/
 notifications:
-  email: false
+  email: <%= @configs['email'] %>
+<% if @configs['irc'] -%>
   irc:
-    on_success: always
-    on_failure: always
+    on_success: <%= @configs['irc']['on_success'] %>
+    on_failure: <%= @configs['irc']['on_failure'] %>
     channels:
-      - "chat.freenode.org#voxpupuli-notifications"
+<%   @configs['irc']['channels'].each do |channel| -%>
+      - "<%= channel %>"
+<%   end -%>
+<% end -%>
 deploy:
   provider: puppetforge
   user: <%= @configs['user'] %>


### PR DESCRIPTION
This change allows other projects to configure notifications via e-mail or IRC according to their own needs. Otherwise we may receive their notifications in our IRC channel. 

The following entries in the file ```.sync.yml``` configure an e-mail address and deactivate the notifications via IRC.

```
.travis.yml:
  email: "notify@example.com"
  irc: false
```