### PR TITLE
Add `keepalived` and `redis` modules

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -43,6 +43,7 @@
 - puppet-jira
 - puppet-jolokia
 - puppet-kafka
+- puppet-keepalived
 - puppet-letsencrypt
 - puppet-lldpd
 - puppet-logrotate
@@ -74,6 +75,7 @@
 - puppet-python
 - puppet-r10k
 - puppet-rabbitmq
+- puppet-redis
 - puppet-report_hipchat
 - puppet-rhsm
 - puppet-rsyslog


### PR DESCRIPTION
These modules are being migrated from the `arioch` namespace