### PR TITLE
Add default mocking framework

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -137,5 +137,7 @@ spec/acceptance/nodesets/ubuntu-server-1404-x64.yml:
   delete: true
 spec/acceptance/nodesets/ubuntu-server-1604-x64.yml:
   delete: true
+spec/spec_helper.rb:
+  mock_with: ':rspec'
 ...
 # vim: syntax=yaml


### PR DESCRIPTION
This will fix the deprecation warning:

```
puppetlabs_spec_helper: defaults `mock_with` to `:mocha`. See https://github.com/puppetlabs/puppetlabs_spec_helper#mock_with to choose a sensible value for you
```