### PR TITLE
Update puppet-strings to 2.0 release

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -90,7 +90,7 @@ Gemfile:
       - gem: voxpupuli-release
         git: https://github.com/voxpupuli/voxpupuli-release-gem
       - gem: puppet-strings
-        version: '>= 1.0'
+        version: '>= 2.0'
 Rakefile:
   config.user: voxpupuli
   default_disabled_lint_checks:


### PR DESCRIPTION
This updates the puppet-strings gem to version 2.0