### PR TITLE
Clean Rakefile.erb

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -93,12 +93,7 @@ Gemfile:
         version: '>= 2.2'
 Rakefile:
   config.user: voxpupuli
-  default_disabled_lint_checks:
-  - 'relative'
-  - 'disable_140chars'
-  - 'disable_class_inherits_from_params_class'
-  - 'disable_documentation'
-  - 'disable_single_quote_string_with_variables'
+  puppet_lint_checks: []
   puppet_strings_patterns: []
 spec/default_facts.yml:
   delete: true

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -93,6 +93,7 @@ Gemfile:
         version: '>= 2.2'
 Rakefile:
   config.user: voxpupuli
+  exclude_paths: []
   puppet_lint_checks: []
   puppet_strings_patterns: []
 spec/default_facts.yml:

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -99,8 +99,6 @@ Rakefile:
   - 'disable_class_inherits_from_params_class'
   - 'disable_documentation'
   - 'disable_single_quote_string_with_variables'
-  default_enabled_rake_targets:
-  - 'release_checks'
   puppet_strings_patterns: []
 spec/default_facts.yml:
   delete: true

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -29,8 +29,7 @@ PuppetSyntax.exclude_paths = exclude_paths
 
 desc 'Auto-correct puppet-lint offenses'
 task 'lint:auto_correct' do
-  PuppetLint.configuration.fix = true
-  Rake::Task[:lint].invoke
+  Rake::Task[:lint_fix].invoke
 end
 
 desc 'Run acceptance tests'

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -8,10 +8,8 @@ rescue LoadError
 end
 
 PuppetLint.configuration.log_format = '%{path}:%{line}:%{check}:%{KIND}:%{message}'
-PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.absolute_classname_reverse = true
-<% checks = @configs['default_disabled_lint_checks'] + ( @configs['extra_disabled_lint_checks'] || [] ) -%>
-<% checks.each do |check| -%>
+<% @configs['puppet_lint_checks'].each do |check| -%>
 PuppetLint.configuration.send('<%= check %>')
 <% end -%>
 

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -18,10 +18,8 @@ exclude_paths = %w(
   vendor/**/*
   .vendor/**/*
   spec/**/*
-<%- if @configs['exclude_paths'] -%>
-<%-   @configs['exclude_paths'].each do |path|-%>
+<%- @configs['exclude_paths'].each do |path|-%>
   <%= path %>
-<%-   end -%>
 <%- end -%>
 )
 PuppetLint.configuration.ignore_paths = exclude_paths

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -75,27 +75,6 @@ task test_with_coveralls: [:test] do
   end
 end
 
-desc "Print supported beaker sets"
-task 'beaker_sets', [:directory] do |t, args|
-  directory = args[:directory]
-
-  metadata = JSON.load(File.read('metadata.json'))
-
-  (metadata['operatingsystem_support'] || []).each do |os|
-    (os['operatingsystemrelease'] || []).each do |release|
-      if directory
-        beaker_set = "#{directory}/#{os['operatingsystem'].downcase}-#{release}"
-      else
-        beaker_set = "#{os['operatingsystem'].downcase}-#{release}-x64"
-      end
-
-      filename = "spec/acceptance/nodesets/#{beaker_set}.yml"
-
-      puts beaker_set if File.exists? filename
-    end
-  end
-end
-
 desc 'Generate REFERENCE.md'
 task :reference, [:debug, :backtrace] do |t, args|
   patterns = '<%= @configs['puppet_strings_patterns'].join(" ") %>'

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -40,13 +40,8 @@ RSpec::Core::RakeTask.new(:acceptance) do |t|
   t.pattern = 'spec/acceptance'
 end
 
-<% targets = @configs['default_enabled_rake_targets']  - ( @configs['extra_disabled_rake_targets'] || [] ) -%>
-desc 'Run tests <%= targets.join(', ') %>'
-task test: [
-<% targets.each do |t| -%>
-  :<%= t %>,
-<% end -%>
-]
+desc 'Run tests'
+task test: [:release_checks]
 
 namespace :check do
   desc 'Check for trailing whitespace'


### PR DESCRIPTION
dacad9a Simplify the exclude_paths logic

   By always defining a default we can simplify our code and the defaults become a reference documentation.

623a46b Reuse the puppetlabs_spec_helper lint_fix task

   While it's a duplication, our task actually has a better self-documenting name.

702ad3e Simplify lint configuration

   This removes all the duplication that already happens in puppetlabs_spec_helper.

   It also renamed extra_disabled_lint_checks to a more saner puppet_lint_checks. This is safe because no module actually uses this. It's sanfer because disabled implies we're actually disabling them for you.

06be76b Hard alias test to release checks

   No module uses this and it only complicates our Rakefile.

586f9f1 Remove beaker_sets task

   Since we stopped storing beaker nodesets as files in our modules, this task no longer makes sense.