### PR TITLE
Filters out the configured bundler path

### DIFF
--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -9,6 +9,7 @@ end
 <%- end -%>
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
+require 'bundler'
 include RspecPuppetFacts
 
 if File.exist?(File.join(__dir__, 'default_module_facts.yml'))
@@ -47,6 +48,7 @@ if Dir.exist?(File.expand_path('../../lib', __FILE__))
     add_filter '/spec'
     add_filter '/vendor'
     add_filter '/.vendor'
+    add_filter Bundler.configured_bundle_path.path
   end
 end
 


### PR DESCRIPTION
Without this change simplecov shows reports for all the gems 
underneath the configured bundle path.