### PR TITLE
add ability to see puppet debug log via env

### DIFF
--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -12,6 +12,11 @@ require 'rspec-puppet-facts'
 require 'bundler'
 include RspecPuppetFacts
 
+if ENV['DEBUG']
+  Puppet::Util::Log.level = :debug
+  Puppet::Util::Log.newdestination(:console)
+end
+
 if File.exist?(File.join(__dir__, 'default_module_facts.yml'))
   facts = YAML.load(File.read(File.join(__dir__, 'default_module_facts.yml')))
   if facts


### PR DESCRIPTION
This makes debugging rspec tests a little easier by providing the
ability to capture the puppet debug log on stdout.
In order to use it, simply do:

```bash
DEBUG=true bundle exec rspec spec/classes/my_class_spec.rb
```