### PR TITLE
travis: send notifications to voxpupu.li

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -25,6 +25,7 @@
     env: PUPPET_VERSION="~> 5.0" CHECK=build DEPLOY_TO_FORGE=yes
     bundler_args: --without system_tests development release
   email: false
+  webhooks: https://voxpupu.li/incoming/travis
   irc:
     on_success: always
     on_failure: always

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -73,6 +73,7 @@ branches:
   - /^v\d/
 notifications:
   email: <%= @configs['email'] %>
+  webhooks: <%= @configs['webhooks'] %>
 <% if @configs['irc'] -%>
   irc:
     on_success: <%= @configs['irc']['on_success'] %>


### PR DESCRIPTION
To analyse our CI runs, we would like to send notifications to
https://voxpupu.li.

PR of the web application: https://github.com/voxpupuli/vox-pupuli-tasks/pull/97
Test PR with this change: https://github.com/voxpupuli/puppet-zabbix/pull/630