### PR TITLE
default to 3.9.0, not 3.9 facter version

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -131,6 +131,6 @@ spec/acceptance/nodesets/ubuntu-server-1604-x64.yml:
   delete: true
 spec/spec_helper.rb:
   mock_with: ':rspec'
-  facterdb_facts_version: '3.9'
+  facterdb_facts_version: '3.9.0'
 ...
 # vim: syntax=yaml


### PR DESCRIPTION
Using 3.9 triggers a bug in facterdb.