### PR TITLE
drop BEAKER_IS_PE=no beaker argument

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -5,11 +5,11 @@
     # values will replace @@SET@@ with the docker_sets' value
   - rvm: 2.5.3
     services: docker
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=@@SET@@ BEAKER_HYPERVISOR=docker CHECK=beaker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=@@SET@@ BEAKER_HYPERVISOR=docker CHECK=beaker
     bundler_args: --without development release
   - rvm: 2.5.3
     services: docker
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=@@SET@@ BEAKER_HYPERVISOR=docker CHECK=beaker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=@@SET@@ BEAKER_HYPERVISOR=docker CHECK=beaker
     bundler_args: --without development release
   includes:
   - rvm: 2.4.4


### PR DESCRIPTION
This is the default and not needed. I tested it in https://github.com/voxpupuli/puppet-zabbix/pull/634