### PR TITLE
mock facter version based on puppet version

### DIFF
--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -61,7 +61,17 @@ RSpec.configure do |c|
   <%- if @configs['hiera_config'] -%>
   c.hiera_config = <%= @configs['hiera_config'] %>
   <%- end -%>
-  c.default_facter_version = ENV['FACTERDB_FACTS_VERSION'] || '<%= @configs['facterdb_facts_version'] %>'
+  # getting the correct facter version is tricky. We use facterdb as a source to mock facts
+  # see https://github.com/camptocamp/facterdb
+  # people might provide a specific facter version. In that case we use it.
+  # Otherwise we need to match the correct facter version to the used puppet version.
+  # as of 2019-10-31, puppet 5 ships facter 3.11 and puppet 6 ships facter 3.14
+  # https://puppet.com/docs/puppet/5.5/about_agent.html
+  c.default_facter_version = if ENV['FACTERDB_FACTS_VERSION']
+                               ENV['FACTERDB_FACTS_VERSION']
+                             else
+                               Gem::Dependency.new('', ENV['PUPPET_VERSION']).match?('', '5') ? '3.11.0' : '3.14.0'
+                             end
 
   # Coverage generation
   c.after(:suite) do


### PR DESCRIPTION
Getting the correct facter version is tricky. We use facterdb as a source to
mock facts see https://github.com/camptocamp/facterdb. People might provide a
specific facter version. In that case we use it. Otherwise we need to match the
correct facter version to the used puppet version. As of 2019-10-31, puppet 5
ships facter 3.11 and puppet 6 ships facter 3.14
(see https://puppet.com/docs/puppet/5.5/about_agent.html).

This was tested at https://github.com/voxpupuli/puppet-nginx/pull/1355