### PR TITLE
Use voxpupuli fixes branch of GHCG

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -83,7 +83,8 @@ Gemfile:
       - gem: bcrypt_pbkdf
     ':release':
       - gem: github_changelog_generator
-        git: https://github.com/github-changelog-generator/github-changelog-generator
+        git: https://github.com/voxpupuli/github-changelog-generator
+        branch: voxpupuli_essential_fixes
       - gem: puppet-blacksmith
       - gem: voxpupuli-release
       - gem: puppet-strings


### PR DESCRIPTION
These are no features in master compared to the release. Not using a git checkout saves having to always clone it, even when the release group is not being installed.