### PR TITLE
Use the released version of GHCG

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -83,7 +83,7 @@ Gemfile:
       - gem: bcrypt_pbkdf
     ':release':
       - gem: github_changelog_generator
-        git: https://github.com/github-changelog-generator/github-changelog-generator
+        version: '>= 1.15.0'
       - gem: puppet-blacksmith
       - gem: voxpupuli-release
       - gem: puppet-strings


### PR DESCRIPTION
While this isn't perfect and still contains some bugs, there's currently nothing in master that's not also in the gem. Installation is quicker because it doesn't have to clone a git repository which Bundler always does regardless of the groups to figure out dependencies.