### PR TITLE
Update lint config.

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -46,6 +46,7 @@ Gemfile:
       - gem: puppet-lint-unquoted_string-check
       - gem: puppet-lint-variable_contains_upcase
       - gem: puppet-lint-absolute_classname-check
+        version: '>= 2.0.0'
       - gem: puppet-lint-topscope-variable-check
       - gem: puppet-lint-legacy_facts-check
       - gem: puppet-lint-anchor-check

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -93,8 +93,6 @@ Gemfile:
         version: '>= 2.2'
 Rakefile:
   config.user: voxpupuli
-  exclude_paths: []
-  puppet_lint_checks: []
   puppet_strings_patterns: []
 spec/default_facts.yml:
   delete: true

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -8,21 +8,6 @@ rescue LoadError
 end
 
 PuppetLint.configuration.log_format = '%{path}:%{line}:%{check}:%{KIND}:%{message}'
-<% @configs['puppet_lint_checks'].each do |check| -%>
-PuppetLint.configuration.send('<%= check %>')
-<% end -%>
-
-exclude_paths = %w(
-  pkg/**/*
-  vendor/**/*
-  .vendor/**/*
-  spec/**/*
-<%- @configs['exclude_paths'].each do |path|-%>
-  <%= path %>
-<%- end -%>
-)
-PuppetLint.configuration.ignore_paths = exclude_paths
-PuppetSyntax.exclude_paths = exclude_paths
 
 desc 'Auto-correct puppet-lint offenses'
 task 'lint:auto_correct' do

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -8,7 +8,6 @@ rescue LoadError
 end
 
 PuppetLint.configuration.log_format = '%{path}:%{line}:%{check}:%{KIND}:%{message}'
-PuppetLint.configuration.absolute_classname_reverse = true
 <% @configs['puppet_lint_checks'].each do |check| -%>
 PuppetLint.configuration.send('<%= check %>')
 <% end -%>


### PR DESCRIPTION
This version drops the reverse option and always enforces the modern style.

Also cleans up lint path handling. That depends on https://github.com/voxpupuli/puppet-facette/pull/42 since it removes the use of `exclude_paths`.