### PR TITLE
Use voxpupuli-test

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -39,6 +39,7 @@ Gemfile:
   required:
     ':test':
       - gem: voxpupuli-test
+        version: '>= 1.0.0'
       - gem: coveralls
       - gem: simplecov-console
     ':development':

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -38,32 +38,9 @@
 Gemfile:
   required:
     ':test':
-      - gem: puppetlabs_spec_helper
-        version: '>= 2.14.0'
-      - gem: rspec-puppet-facts
-        version: '>= 1.9.5'
-      - gem: rspec-puppet-utils
-      - gem: puppet-lint-leading_zero-check
-      - gem: puppet-lint-trailing_comma-check
-      - gem: puppet-lint-version_comparison-check
-      - gem: puppet-lint-classes_and_types_beginning_with_digits-check
-      - gem: puppet-lint-unquoted_string-check
-      - gem: puppet-lint-variable_contains_upcase
-      - gem: puppet-lint-absolute_classname-check
-        version: '>= 2.0.0'
-      - gem: puppet-lint-topscope-variable-check
-      - gem: puppet-lint-legacy_facts-check
-      - gem: puppet-lint-anchor-check
-      - gem: metadata-json-lint
-      - gem: rubocop
-        version: '~> 0.49.1'
-      - gem: rubocop-rspec
-        version: '~> 1.15.0'
-      - gem: mocha
-        version: '~> 1.4.0'
+      - gem: voxpupuli-test
       - gem: coveralls
       - gem: simplecov-console
-      - gem: parallel_tests
     ':development':
       - gem: travis
       - gem: travis-lint
@@ -141,7 +118,7 @@ spec/acceptance/nodesets/windows-2012-serverstandard-x64.yml:
 spec/acceptance/nodesets/windows-2012R2-serverstandard-x64.yml:
   delete: true
 spec/spec_helper.rb:
-  mock_with: ':rspec'
+  mock_with: false
 CONTRIBUTING.md:
   delete: true
 ...

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -1,4 +1,4 @@
-require 'puppetlabs_spec_helper/rake_tasks'
+require 'voxpupuli/test/rake'
 
 # load optional tasks for releases
 # only available if gem group releases is installed
@@ -6,37 +6,6 @@ begin
   require 'voxpupuli/release/rake_tasks'
 rescue LoadError
 end
-
-PuppetLint.configuration.log_format = '%{path}:%{line}:%{check}:%{KIND}:%{message}'
-
-desc 'Auto-correct puppet-lint offenses'
-task 'lint:auto_correct' do
-  Rake::Task[:lint_fix].invoke
-end
-
-desc 'Run acceptance tests'
-RSpec::Core::RakeTask.new(:acceptance) do |t|
-  t.pattern = 'spec/acceptance'
-end
-
-desc 'Run tests'
-task test: [:release_checks]
-
-namespace :check do
-  desc 'Check for trailing whitespace'
-  task :trailing_whitespace do
-    Dir.glob('**/*.md', File::FNM_DOTMATCH).sort.each do |filename|
-      next if filename =~ %r{^((modules|acceptance|\.?vendor|spec/fixtures|pkg)/|REFERENCE.md|CHANGELOG.md)}
-      File.foreach(filename).each_with_index do |line, index|
-        if line =~ %r{\s\n$}
-          puts "#{filename} has trailing whitespace on line #{index + 1}"
-          exit 1
-        end
-      end
-    end
-  end
-end
-Rake::Task[:release_checks].enhance ['check:trailing_whitespace']
 
 desc "Run main 'test' task and report merged results to coveralls"
 task test_with_coveralls: [:test] do

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -15,9 +15,7 @@ end
 
 # puppetlabs_spec_helper will set up coverage if the env variable is set.
 # We want to do this if lib exists and it hasn't been explicitly set.
-if Dir.exist?(File.expand_path('../../lib', __FILE__))
-  ENV['COVERAGE'] ||= 'yes'
-end
+ENV['COVERAGE'] ||= 'yes' if Dir.exist?(File.expand_path('../../lib', __FILE__))
 
 require 'voxpupuli/test/spec_helper'
 
@@ -29,8 +27,8 @@ if File.exist?(File.join(__dir__, 'default_module_facts.yml'))
     end
   end
 end
-
 <% if @configs['augeasproviders'] -%>
+
 # Setup augeasproviders
 require 'pathname'
 dir = Pathname.new(__FILE__).parent

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -11,8 +11,14 @@ RSpec.configure do |c|
   c.hiera_config = <%= @configs['hiera_config'] %>
   <%- end -%>
 end
-
 <%- end -%>
+
+# puppetlabs_spec_helper will set up coverage if the env variable is set.
+# We want to do this if lib exists and it hasn't been explicitly set.
+if Dir.exist?(File.expand_path('../../lib', __FILE__))
+  ENV['COVERAGE'] ||= 'yes'
+end
+
 require 'voxpupuli/test/spec_helper'
 
 if File.exist?(File.join(__dir__, 'default_module_facts.yml'))
@@ -38,23 +44,6 @@ puts 'augeasproviders: setting Puppet[:libdir] to work around broken type autolo
 Puppet[:libdir] = "#{Puppet[:modulepath]}/augeasproviders_core/lib"
 
 <% end -%>
-if Dir.exist?(File.expand_path('../../lib', __FILE__))
-  require 'coveralls'
-  require 'simplecov'
-  require 'simplecov-console'
-  SimpleCov.formatters = [
-    SimpleCov::Formatter::HTMLFormatter,
-    SimpleCov::Formatter::Console
-  ]
-  SimpleCov.start do
-    track_files 'lib/**/*.rb'
-    add_filter '/spec'
-    add_filter '/vendor'
-    add_filter '/.vendor'
-    add_filter Bundler.configured_bundle_path.path
-  end
-end
-
 <%- [@configs['spec_overrides']].flatten.compact.each do |line| -%>
 
 <%= line %>

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -1,21 +1,19 @@
 # This file is managed via modulesync
 # https://github.com/voxpupuli/modulesync
 # https://github.com/voxpupuli/modulesync_config
-<%- if @configs['mock_with'] -%>
+<%- if @configs['mock_with'] || @configs['hiera_config'] -%>
+
 RSpec.configure do |c|
+  <%- if @configs['mock_with'] -%>
   c.mock_with <%= @configs['mock_with'] %>
+  <%- end -%>
+  <%- if @configs['hiera_config'] -%>
+  c.hiera_config = <%= @configs['hiera_config'] %>
+  <%- end -%>
 end
 
 <%- end -%>
-require 'puppetlabs_spec_helper/module_spec_helper'
-require 'rspec-puppet-facts'
-require 'bundler'
-include RspecPuppetFacts
-
-if ENV['DEBUG']
-  Puppet::Util::Log.level = :debug
-  Puppet::Util::Log.newdestination(:console)
-end
+require 'voxpupuli/test/spec_helper'
 
 if File.exist?(File.join(__dir__, 'default_module_facts.yml'))
   facts = YAML.load(File.read(File.join(__dir__, 'default_module_facts.yml')))
@@ -57,31 +55,6 @@ if Dir.exist?(File.expand_path('../../lib', __FILE__))
   end
 end
 
-RSpec.configure do |c|
-  <%- if @configs['hiera_config'] -%>
-  c.hiera_config = <%= @configs['hiera_config'] %>
-  <%- end -%>
-  # getting the correct facter version is tricky. We use facterdb as a source to mock facts
-  # see https://github.com/camptocamp/facterdb
-  # people might provide a specific facter version. In that case we use it.
-  # Otherwise we need to match the correct facter version to the used puppet version.
-  # as of 2019-10-31, puppet 5 ships facter 3.11 and puppet 6 ships facter 3.14
-  # https://puppet.com/docs/puppet/5.5/about_agent.html
-  #
-  # The environment variable `PUPPET_VERSION` is available in our travis environment, but we cannot rely on it
-  # if somebody runs the tests locally. For that case we should fallback the the puppet gem version.
-  c.default_facter_version = if ENV['FACTERDB_FACTS_VERSION']
-                               ENV['FACTERDB_FACTS_VERSION']
-                             else
-                               puppet_version = ENV['PUPPET_VERSION'] ? ENV['PUPPET_VERSION'] : Gem.loaded_specs['puppet'].version.to_s
-                               Gem::Dependency.new('', puppet_version).match?('', '5') ? '3.11.0' : '3.14.0'
-                             end
-
-  # Coverage generation
-  c.after(:suite) do
-    RSpec::Puppet::Coverage.report!
-  end
-end
 <%- [@configs['spec_overrides']].flatten.compact.each do |line| -%>
 
 <%= line %>


### PR DESCRIPTION
This gem has most of the duplication that used to be modulesynced. By moving it to a gem, the need for modulesyncing is greatly reduced.

Currently a draft since we should do some bikeshedding and the gem should live in the Voxpupuli org.

Ideally we'd end up with by default a single line in `spec_helper.rb` that is `require 'voxpupuli/test/spec_helper'`. Whenever a module then needs overrides, it can be done by unmanaging the file rather than the complex .sync.yml dance that's done now.