### PR TITLE
Skip command gem update

### DIFF
--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -22,7 +22,6 @@ addons:
 <%- end -%>
 before_install:
   - yes | gem update --system
-  - gem update bundler
   - bundle --version
 script:
   - 'bundle exec rake $CHECK'


### PR DESCRIPTION
This command is not necessary, because the gem ```rubygems-update``` will provide the executable ```bundle``` and the command ```gem update --system``` will make sure that it is up to date. 