### PR TITLE
delete CONTRIBUTING.md in all repos

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -139,5 +139,7 @@ spec/acceptance/nodesets/windows-2012R2-serverstandard-x64.yml:
   delete: true
 spec/spec_helper.rb:
   mock_with: ':rspec'
+CONTRIBUTING.md:
+  delete: true
 ...
 # vim: syntax=yaml


### PR DESCRIPTION
Some repos still have this file in their document root. We provide one
into .github/CONTRIBUTING.md, so we need to delete the duplicate one.