### PR TITLE
Add ed25519 gem

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -84,6 +84,7 @@ Gemfile:
         version: '>= 4'
       - gem: rbnacl-libsodium
       - gem: bcrypt_pbkdf
+      - gem: ed25519
     ':release':
       - gem: github_changelog_generator
         git: https://github.com/voxpupuli/github-changelog-generator


### PR DESCRIPTION
When running specs for puppet-nginx on my local machine I tripped over:

```
An error occurred while loading ./spec/acceptance/nginx_upstream_spec.rb.
Failure/Error: require 'beaker-rspec'
NotImplementedError:
  unsupported key type `ssh-ed25519'
  net-ssh requires the following gems for ed25519 support:
   * ed25519 (>= 1.2, < 2.0)
   * bcrypt_pbkdf (>= 1.0, < 2.0)
  See https://github.com/net-ssh/net-ssh/issues/565 for more information
  Gem::LoadError : "ed25519 is not part of the bundle. Add it to your Gemfile."
```

Is this the right place to add the missing dependency?

