### PR TITLE
State centos8 as working docker container

### DIFF
--- a/moduleroot/.github/CONTRIBUTING.md.erb
+++ b/moduleroot/.github/CONTRIBUTING.md.erb
@@ -269,6 +269,7 @@ The following strings are known to work:
 * debian10
 * centos6
 * centos7
+* centos8
 
 The easiest way to debug in a docker container is to open a shell:
 


### PR DESCRIPTION
Using a docker8 container for acceptence tests now works
as demonstrated by the earlyoom module.