### PR TITLE
Make 'before_install' in .travis.yml configurable

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -1,5 +1,8 @@
 ---
 .travis.yml:
+  before_install:
+    - yes | gem update --system
+    - bundle --version
   docker_sets:
   docker_defaults:
     # values will replace @@SET@@ with the docker_sets' value

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -20,9 +20,12 @@ addons:
     <%- end -%>
   <%- end -%>
 <%- end -%>
+<%- if @configs['before_install'] -%>
 before_install:
-  - yes | gem update --system
-  - bundle --version
+<% @configs['before_install'].each do |bi| -%>
+  - <%= bi %>
+<% end -%>
+<%- end -%>
 script:
   - 'bundle exec rake $CHECK'
 matrix:


### PR DESCRIPTION
This is needed to be able clone the puppetlabs-ruby_task_helper for
Bolt task spec tests.

See https://github.com/puppetlabs/puppetlabs-azure_inventory/blob/fee6f7e93559d5e72e3e6763a415883612f36a73/.travis.yml#L6 as an example of what I'd like to do.