### PR TITLE
Fix command to get latest tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Module sync configurations for Vox Pupuli Modules
 ```bash
 git clone https://github.com/voxpupuli/modulesync_config.git
 cd modulesync_config
-git checkout $(git tag --list | tail -n 1) # checkout latest tag
+git checkout $(git tag --list | sort -V | tail -n1) # checkout latest tag
 bundle install
 bundle exec msync help update
 ```


### PR DESCRIPTION
The command ```git tag --list | tail -n 1``` does not point to the latest tag:
```
git tag --list | tail -n 1
2.9.0
```

This is related to the sorting of the tags:
```
git tag --list
...
2.0.0
2.1.0
2.10.0
2.10.1
2.2.0
2.3.0
2.4.0
2.5.0
2.6.0
2.7.0
2.8.0
2.9.0
```

The command ```git describe --abbrev=0``` will actually point to the latest tag:
```
git describe --abbrev=0
2.10.1
```
