### PR TITLE
Revert rubocop TargetRubyVersion back to 1.9

### DIFF
--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -1,6 +1,7 @@
 require: rubocop-rspec
 AllCops:
-  TargetRubyVersion: 2.1
+# Puppet Server 5 defaults to jruby 1.7 so TargetRubyVersion must stay at 1.9 until we drop support for puppet 5
+  TargetRubyVersion: 1.9
   Include:
     - ./**/*.rb
   Exclude:


### PR DESCRIPTION
Puppet Server 5 isn't fully EOL until Nov 2020.  By default it uses
jruby 1.7 which is only Ruby 1.9 compatible.  Targetting ruby 2.1
already broke one module.  See https://github.com/voxpupuli/puppet-firewalld/issues/250

Alternatively, we could tweak the various cops to try to remain
compatible.  But why?  This doesn't provide value over just setting
`TargetRubyVersion` to what we need it to be.

When puppet 5 goes EOL, we can bump this back up and move to a newer
version of rubocop too. Until then, I don't think we're really missing
out all that much.