### PR TITLE
Drop `redcarpet` gem

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -55,7 +55,6 @@ Gemfile:
       - gem: puppet-lint-legacy_facts-check
       - gem: puppet-lint-anchor-check
       - gem: metadata-json-lint
-      - gem: redcarpet
       - gem: rubocop
         version: '~> 0.49.1'
       - gem: rubocop-rspec


### PR DESCRIPTION
Initially introduced in da540ad5f56192c07f2e764c484431264b62fe7b as a
missing dependency to puppet-strings. I tested this on the puppet-borg
module. The gem isn't required to build our REFERENCE.md.