### PR TITLE
Use voxpupuli-acceptance

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -8,11 +8,11 @@
     # values will replace @@SET@@ with the docker_sets' value
   - rvm: 2.5.3
     services: docker
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=@@SET@@ BEAKER_HYPERVISOR=docker CHECK=beaker
+    env: BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=@@SET@@ CHECK=beaker
     bundler_args: --without development release
   - rvm: 2.5.3
     services: docker
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=@@SET@@ BEAKER_HYPERVISOR=docker CHECK=beaker
+    env: BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=@@SET@@ CHECK=beaker
     bundler_args: --without development release
   includes:
   - rvm: 2.4.4
@@ -49,22 +49,7 @@ Gemfile:
       - gem: overcommit
         version: '>= 0.39.1'
     ':system_tests':
-      - gem: winrm
-      - gem: beaker-rspec
-        version: '>= 6'
-      - gem: serverspec
-      - gem: beaker-hostgenerator
-        version: '>= 1.1.22'
-      - gem: beaker-docker
-      - gem: beaker-puppet
-      - gem: beaker-puppet_install_helper
-      - gem: beaker-module_install_helper
-        require: false
-      - gem: rbnacl
-        version: '>= 4'
-      - gem: rbnacl-libsodium
-      - gem: bcrypt_pbkdf
-      - gem: ed25519
+      - gem: voxpupuli-acceptance
     ':release':
       - gem: github_changelog_generator
         git: https://github.com/voxpupuli/github-changelog-generator
@@ -120,6 +105,8 @@ spec/acceptance/nodesets/windows-2012R2-serverstandard-x64.yml:
   delete: true
 spec/spec_helper.rb:
   mock_with: false
+spec/spec_helper_acceptance.rb:
+  unmanaged: true
 CONTRIBUTING.md:
   delete: true
 ...

--- a/moduleroot/spec/spec_helper_acceptance.rb.erb
+++ b/moduleroot/spec/spec_helper_acceptance.rb.erb
@@ -1,0 +1,3 @@
+require 'voxpupuli/acceptance/spec_helper_acceptance'
+
+configure_beaker


### PR DESCRIPTION
This moves a lot of logic from modulesync into a [gem](https://github.com/voxpupuli/voxpupuli-acceptance). This greatly reduces the amount of code we have to sync. It also starts to manage spec_acceptance_helper.rb in various modules when they only need a trivial helper.

* [x] https://github.com/voxpupuli/puppet-autofs/pull/159
* [x] https://github.com/voxpupuli/puppet-bird/pull/46
* [x] https://github.com/voxpupuli/puppet-borg/pull/54
* [x] https://github.com/voxpupuli/puppet-caddy/pull/25
* [ ] https://github.com/voxpupuli/puppet-check_mk/pull/31
* [x] https://github.com/voxpupuli/puppet-collectd/pull/934
* [x] https://github.com/voxpupuli/puppet-community_kickstarts/pull/64
* [x] https://github.com/voxpupuli/puppet-confluence/pull/199
* [x] https://github.com/voxpupuli/puppet-dhcp/pull/242
* [x] https://github.com/voxpupuli/puppet-dropbear/pull/38
* [x] https://github.com/voxpupuli/puppet-etherpad/pull/97
* [x] https://github.com/voxpupuli/puppet-facette/pull/46
* [x] https://github.com/voxpupuli/puppet-fail2ban/pull/136
* [x] https://github.com/voxpupuli/puppet-ferm/pull/97
* [x] https://github.com/voxpupuli/puppet-fetchcrl/pull/65
* [x] https://github.com/voxpupuli/puppet-ghost/pull/100
* [x] https://github.com/voxpupuli/puppet-gitlab/pull/335
* [x] https://github.com/voxpupuli/puppet-gitlab_ci_runner/pull/83
* [x] https://github.com/voxpupuli/puppet-gluster/pull/213
* [x] https://github.com/voxpupuli/puppet-graphite_powershell/pull/54
* [x] https://github.com/voxpupuli/puppet-hiera/pull/284
* [x] https://github.com/voxpupuli/puppet-ipset/pull/32
* [ ] https://github.com/voxpupuli/puppet-jenkins/pull/963
* [x] https://github.com/voxpupuli/puppet-jenkins_job_builder/pull/95
* [ ] https://github.com/voxpupuli/puppet-jira/pull/314
* [x] https://github.com/voxpupuli/puppet-kafka/pull/296
* [x] https://github.com/voxpupuli/puppet-keepalived/pull/208
* [x] https://github.com/voxpupuli/puppet-letsencrypt/pull/224
* [x] https://github.com/voxpupuli/puppet-lldpd/pull/83
* [x] https://github.com/voxpupuli/puppet-logrotate/pull/172
* [x] https://github.com/voxpupuli/puppet-mlocate/pull/16
* [x] https://github.com/voxpupuli/puppet-module/pull/18
* [x] https://github.com/voxpupuli/puppet-mongodb/pull/580
* [x] https://github.com/voxpupuli/puppet-mumble/pull/62
* [x] https://github.com/voxpupuli/puppet-mysql_java_connector/pull/68
* [x] https://github.com/voxpupuli/puppet-nrpe/pull/33
* [x] https://github.com/voxpupuli/puppet-nscd/pull/62
* [x] https://github.com/voxpupuli/puppet-prometheus/pull/441
* [x] https://github.com/voxpupuli/puppet-proxysql/pull/144
* [ ] https://github.com/voxpupuli/puppet-python/pull/543
* [x] https://github.com/voxpupuli/puppet-r10k/pull/524
* [x] https://github.com/voxpupuli/puppet-rabbitmq/pull/831
* [x] https://github.com/voxpupuli/puppet-rsyslog/pull/149
* [x] https://github.com/voxpupuli/puppet-sftp_jail/pull/62
* [x] https://github.com/voxpupuli/puppet-snmp/pull/221
* [ ] https://github.com/voxpupuli/puppet-spiped/pull/20
* [ ] https://github.com/voxpupuli/puppet-splunk/pull/283
* [x] https://github.com/voxpupuli/puppet-squid/pull/147
* [x] https://github.com/voxpupuli/puppet-ssh_keygen/pull/57
* [x] https://github.com/voxpupuli/puppet-strongswan/pull/43
* [x] https://github.com/voxpupuli/puppet-telegraf/pull/142
* [x] https://github.com/voxpupuli/puppet-trusted_ca/pull/23
* [x] https://github.com/voxpupuli/puppet-tvheadend/pull/38
* [x] https://github.com/voxpupuli/puppet-virtualbox/pull/114
* [x] https://github.com/voxpupuli/puppet-wget/pull/114
* [x] https://github.com/voxpupuli/puppet-yum/pull/163