### PR TITLE
spec_helper_acceptance: Add helper to load custom files

### DIFF
--- a/moduleroot/spec/spec_helper_acceptance.rb.erb
+++ b/moduleroot/spec/spec_helper_acceptance.rb.erb
@@ -1,3 +1,6 @@
+# This file is completely managed via modulesync
 require 'voxpupuli/acceptance/spec_helper_acceptance'
 
 configure_beaker
+
+Dir['./spec/support/acceptance/**/*.rb'].sort.each { |f| require f }


### PR DESCRIPTION
This allows us to keept the spec_helper_acceptance clean and managed by
modulesync, but it also provides enough flexibility for our module
developers to inject custom code into the test suite.

Also this alligns our setup with the one from the foreman people.