### PR TITLE
Fix typo in version comparison

### DIFF
--- a/bin/get_all_the_diffs
+++ b/bin/get_all_the_diffs
@@ -161,7 +161,7 @@ doesnt_support_latest_centos.sort!.uniq!
 need_another_sync = []
 versions.each do |repo|
   # index 0 is the module name, index 1 is the used modulesync_config version
-  need_another_sync << repo[0] if Gem::Version.new(latest_release) >= Gem::Version.new(repo[1])
+  need_another_sync << repo[0] if Gem::Version.new(latest_release) > Gem::Version.new(repo[1])
 end
 
 # generate some output


### PR DESCRIPTION
prior to that change, we detected systems with up2date msync as outdated