### PR TITLE
Update voxpupuli-test 1.0.0->1.4.0

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -39,7 +39,7 @@ Gemfile:
   required:
     ':test':
       - gem: voxpupuli-test
-        version: '>= 1.0.0'
+        version: '>= 1.4.0'
       - gem: coveralls
       - gem: simplecov-console
     ':development':


### PR DESCRIPTION
Version 1.4.0 now pulls in a suitable facter version and not latest.
Other gems already depend on facter < 4. Without this change, we don't
get latest facterdb code, which in turn brings us Debian 10 Facter 3.14
factsets.