### PR TITLE
Manage GitHub settings via Probot

### DIFF
--- a/moduleroot/.github/settings.yml
+++ b/moduleroot/.github/settings.yml
@@ -1,0 +1,36 @@
+repository:
+  private: false
+  has_issues: true
+  has_projects: false
+  has_wiki: false
+  has_downloads: true
+  default_branch: master
+  allow_squash_merge: true
+  allow_merge_commit: true
+  allow_rebase_merge: true
+  delete_branch_on_merge: true
+  archived: false
+
+branches:
+  - name: master
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: true
+      required_status_checks:
+        strict: true
+        contexts: ['continuous-integration/travis-ci']
+      enforce_admins: true
+      restrictions: null
+      required_signatures: true
+  - name: modulesync
+    protection:
+      required_pull_request_reviews: null
+      required_status_checks:
+        strict: true
+        contexts: ['continuous-integration/travis-ci']
+      enforce_admins: true
+      restrictions: null
+      required_signatures: true
+

--- a/moduleroot/CODEOWNERS
+++ b/moduleroot/CODEOWNERS
@@ -1,0 +1,3 @@
+.github/settings.yml @voxpupuli/project-maintainers
+
+* @voxpupuli/collaborators


### PR DESCRIPTION
This pull request allows us to manage the GitHub settings via Probot. I left out the labels, as they are managed by ```vox-pupuli-tasks```. 

Maybe we can also read the file ```metadata.json``` to automatically add values for ```name```, ```description```, ```homepage``` and ```topics```. 

Unfortunately, the ```delete_merge_on_branch``` parameter does not work yet: 
* https://github.com/probot/settings/issues/134

Also, the rule for the ```modulesync``` branch will not be applied if it does not already exist:
* https://github.com/probot/settings/issues/136