### PR TITLE
Disable RSpec/MultipleExpectations

### DIFF
--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -533,6 +533,9 @@ RSpec/RepeatedDescription:
 RSpec/NestedGroups:
   Enabled: False
 
+RSpec/MultipleExpectations:
+  Enabled: false
+
 # this is broken on ruby1.9
 Layout/IndentHeredoc:
   Enabled: False


### PR DESCRIPTION
This would allow us to upgrade rubocop-rspec to 1.16 without creating a
whole bunch of extra work.

See https://github.com/voxpupuli/voxpupuli-test/pull/26