### PR TITLE
Remove puppet-puppetserver from modules

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -90,7 +90,6 @@
 - puppet-proxysql
 - puppet-prosody
 - puppet-puppetboard
-- puppet-puppetserver
 - puppet-pxe
 - puppet-python
 - puppet-r10k

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -28,21 +28,6 @@ if File.exist?(File.join(__dir__, 'default_module_facts.yml'))
     end
   end
 end
-<% if @configs['augeasproviders'] -%>
-
-# Setup augeasproviders
-require 'pathname'
-dir = Pathname.new(__FILE__).parent
-$LOAD_PATH.unshift(dir, File.join(dir, 'fixtures/modules/augeasproviders_core/spec/lib'), File.join(dir, '..', 'lib'))
-require 'augeas_spec'
-require 'pathname'
-dir = Pathname.new(__FILE__).parent
-Puppet[:modulepath] = File.join(dir, 'fixtures', 'modules')
-puts 'augeasproviders: setting Puppet[:libdir] to work around broken type autoloading'
-# libdir is only a single dir, so it can only workaround loading of one external module
-Puppet[:libdir] = "#{Puppet[:modulepath]}/augeasproviders_core/lib"
-
-<% end -%>
 <%- [@configs['spec_overrides']].flatten.compact.each do |line| -%>
 
 <%= line %>


### PR DESCRIPTION
Per https://github.com/voxpupuli/puppet-puppetserver/issues/69 this module is deprecated. While some people wanted to see it maintained, nobody stepped up. There is no point in trying to modulesync it.