### PR TITLE
drop deprecated wget module

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -125,7 +125,6 @@
 - puppet-vault_lookup
 - puppet-virtualbox
 - puppet-visualstudio
-- puppet-wget
 - puppet-windows_autoupdate
 - puppet-windows_env
 - puppet-windows_eventlog


### PR DESCRIPTION
we already deprecated it on the forge: https://forge.puppet.com/puppet/wget