### PR TITLE
Disable Style/BracesAroundHashParameters

### DIFF
--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -157,7 +157,7 @@ Style/Attr:
   Enabled: True
 
 Style/BracesAroundHashParameters:
-  Enabled: True
+  Enabled: False
 
 Style/CaseEquality:
   Enabled: True


### PR DESCRIPTION
We shouldn't use this anymore as ruby 2.7 will warn without the braces
and they will be required in ruby 3.

PDK has already made this change in https://github.com/puppetlabs/pdk-templates/commit/7e5604527a52e25e34eb704f25af6535f4115bf8