### PR TITLE
Enable Security/YAMLLoad cop

### DIFF
--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -540,9 +540,8 @@ RSpec/MultipleExpectations:
 Layout/IndentHeredoc:
   Enabled: False
 
-# disable Yaml safe_load. This is needed to support ruby2.0.0 development envs
 Security/YAMLLoad:
-  Enabled: false
+  Enabled: True
 
 # This affects hiera interpolation, as well as some configs that we push.
 Style/FormatStringToken:


### PR DESCRIPTION
Luckily we no longer have to care about Ruby 2.0 development environments and using safe_load is a good practice.