### PR TITLE
dont manage mcollective module

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -60,7 +60,6 @@
 - puppet-lldpd
 - puppet-logrotate
 - puppet-make
-- puppet-mcollective
 - puppet-metche
 - puppet-minecraft
 - puppet-misp


### PR DESCRIPTION
the module is deprecated, choria-io maintains up2date versions.