### PR TITLE
Use corresponding ruby versions for the Puppet versions while testing

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -7,25 +7,25 @@
   docker_sets:
   docker_defaults:
     # values will replace @@SET@@ with the docker_sets' value
-    - rvm: 2.5.3
+    - rvm: 2.5.7
       services: docker
       env: BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=@@SET@@ CHECK=beaker
       bundler_args: --without development release
-    - rvm: 2.5.3
+    - rvm: 2.5.7
       services: docker
       env: BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=@@SET@@ CHECK=beaker
       bundler_args: --without development release
   includes:
-    - rvm: 2.4.4
+    - rvm: 2.4.9
       env: PUPPET_VERSION="~> 5.0" CHECK=test
       bundler_args: --without system_tests development release
-    - rvm: 2.5.3
+    - rvm: 2.5.7
       env: PUPPET_VERSION="~> 6.0" CHECK=test_with_coveralls
       bundler_args: --without system_tests development release
-    - rvm: 2.5.3
+    - rvm: 2.5.7
       env: PUPPET_VERSION="~> 6.0" CHECK=rubocop
       bundler_args: --without system_tests development release
-    - rvm: 2.4.4
+    - rvm: 2.4.9
       env: PUPPET_VERSION="~> 5.0" CHECK=build DEPLOY_TO_FORGE=yes
       bundler_args: --without system_tests development release
   email: false

--- a/moduleroot/Dockerfile.erb
+++ b/moduleroot/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM ruby:2.5.3
+FROM ruby:2.5.7
 
 WORKDIR /opt/puppet
 


### PR DESCRIPTION
Current Puppet 6 uses ruby 2.5.7 and Puppet 5 uses 2.4.9.

https://puppet.com/docs/puppet/latest/about_agent.html
https://puppet.com/docs/puppet/5.5/about_agent.html