### PR TITLE
CONTRIBUTING.md: Drop CentOS 6 note

### DIFF
--- a/moduleroot/.github/CONTRIBUTING.md.erb
+++ b/moduleroot/.github/CONTRIBUTING.md.erb
@@ -269,7 +269,6 @@ The following strings are known to work:
 * ubuntu2004
 * debian9
 * debian10
-* centos6
 * centos7
 * centos8
 


### PR DESCRIPTION
CentOS 6 is EOL by the end of November 2020. We can already remove it
from our example documentation.