### PR TITLE
Don't ship `spec` directory, `Rakefile` or `Gemfile` in packaged modules

### DIFF
--- a/moduleroot/.pmtignore.erb
+++ b/moduleroot/.pmtignore.erb
@@ -1,11 +1,12 @@
 docs/
 pkg/
+Gemfile
 Gemfile.lock
 Gemfile.local
 vendor/
 .vendor/
-spec/fixtures/manifests/
-spec/fixtures/modules/
+spec/
+Rakefile
 .vagrant/
 .bundle/
 .ruby-version


### PR DESCRIPTION
This should make the average module a fair bit smaller.
PDK already does this by default.
https://github.com/puppetlabs/pdk-templates/blob/172738acbf55e65afb1eb8541deb8bb242ca877b/config_defaults.yml#L57