### PR TITLE
CONTRIBUTING template: fix name of acceptance test rake task

### DIFF
--- a/moduleroot/.github/CONTRIBUTING.md.erb
+++ b/moduleroot/.github/CONTRIBUTING.md.erb
@@ -232,14 +232,14 @@ simple tests against it after applying the module. You can run this
 with:
 
 ```sh
-bundle exec rake acceptance
+bundle exec rake beaker
 ```
 
 This will run the tests on the module's default nodeset. You can override the
 nodeset used, e.g.,
 
 ```sh
-BEAKER_set=centos-7-x64 bundle exec rake acceptance
+BEAKER_set=centos-7-x64 bundle exec rake beaker
 ```
 
 There are default rake tasks for the various acceptance test modules, e.g.,


### PR DESCRIPTION
It's "beaker", not "acceptance". The task name is defined here:
https://github.com/puppetlabs/puppetlabs_spec_helper/blob/121a67515480c15561bcc67271dab4a82f87ffa8/lib/puppetlabs_spec_helper/tasks/beaker.rb