### PR TITLE
Extend .pmtignore to trim modules

### DIFF
--- a/moduleroot/.pmtignore.erb
+++ b/moduleroot/.pmtignore.erb
@@ -14,11 +14,23 @@ coverage/
 log/
 .idea/
 .dependencies/
+.github/
 .librarian/
 Puppetfile.lock
 *.iml
+.editorconfig
+.fixtures.yml
+.gitignore
+.msync.yml
+.overcommit.yml
+.pmtignore
+.rspec
+.rspec_parallel
+.rubocop.yml
+.sync.yml
 .*.sw?
 .yardoc/
+.yardopts
 Dockerfile
 <% if ! @configs['paths'].nil? -%>
 <% @configs['paths'].each do |path| -%>


### PR DESCRIPTION
This follows c294770cb0b2608cc498fd7aeace60a2888b2106 which dropped specs. It now also drops all hidden files that serve no purpose on production environments.