### PR TITLE
Use ruby/setup-ruby in workflow testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 name: noop run
 
-on: pull_request
+on:
+  - pull_request
+  - push
 
 jobs:
   unit:
@@ -9,19 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-      - uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-2.7-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-2.7-gems-
-      - name: Install dependencies
-        run: |
-          gem install bundler
-          bundle config path vendor/bundle
-          bundle install --jobs $(nproc) --retry 3
+          bundler-cache: true
       - name: Run msync --noop
         run: bundle exec msync update --noop --git-base=https://github.com/


### PR DESCRIPTION
This action has built in caching the right way, which makes it easier. It also runs on push events because that gives a shared cache. There is no shared cache on PR testing for (valid) security reasons.