### PR TITLE
Run rubocop checks in matrix build

### DIFF
--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -11,7 +11,7 @@ jobs:
       puppet_major_versions: ${{ steps.get-outputs.outputs.puppet_major_versions }}
       puppet_unit_test_matrix: ${{ steps.get-outputs.outputs.puppet_unit_test_matrix }}
     env:
-      BUNDLE_WITHOUT: development:test:release
+      BUNDLE_WITHOUT: development:release
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby
@@ -21,6 +21,8 @@ jobs:
           bundler-cache: true
       - name: Run rake validate
         run: bundle exec rake validate
+      - name: Run rake rubocop
+        run: bundle exec rake rubocop
       - name: Setup Test Matrix
         id: get-outputs
         run: bundle exec metadata2gha --use-fqdn --pidfile-workaround <%= @configs['pidfile_workaround'] %>


### PR DESCRIPTION
Run `bundle exec rake rubocop`.

This requires we install voxpupuli-test to get the rubocop
dependencies.