### PR TITLE
Introduce default job length of 40 minutes

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -4,6 +4,7 @@
   beaker_fact_matrix: {}
   excludes: []
   pidfile_workaround: false
+  timeout_minutes: 40
 .travis.yml:
   delete: true
 Gemfile:

--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -6,6 +6,7 @@ jobs:
   setup_matrix:
     name: 'Setup Test Matrix'
     runs-on: ubuntu-latest
+    timeout-minutes: <%= @configs['timeout_minutes'] %>
     outputs:
       beaker_setfiles: ${{ steps.get-outputs.outputs.beaker_setfiles }}
       puppet_major_versions: ${{ steps.get-outputs.outputs.puppet_major_versions }}
@@ -28,6 +29,7 @@ jobs:
   unit:
     needs: setup_matrix
     runs-on: ubuntu-latest
+    timeout-minutes: <%= @configs['timeout_minutes'] %>
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Override default job timeout for Github actions.

Set the job timeout to 40 minutes rather than the default
360 minutes (6 hours)

Running some test jobs with 1 minute the queued time per job does not
appear to count to the limit which is desirable.

Job timeout can be overridden in `.sync.yml`.

https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes