### PR TITLE
remove unroutable ipv6 config

### DIFF
--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -79,10 +79,6 @@ jobs:
     -%>
     name: <%= name.join(' - ') %>
     steps:
-      - name: Enable IPv6 on docker
-        run: |
-          echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
-          sudo service docker restart
       - uses: actions/checkout@v2
       - name: Setup ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
The current configuration configures the docker daemon to issue ipv6
addresses in an RFC 3849 IPv6 documentation range[1], most Likely copied f
rom the docker documentation[2].  I suspect that theses images dont have
any additional IPv6 prefixes delegated to them so im not sure any value
makes senses here.

I suspect that this is never the desired outcome as it means the docker
instance gets configured with a un-routable global IPv6 address.  This
means outgoing connections will first try to connect to resources via
IPv6 (if a AAAA is avalible) and time out before trying IPv4.  This can
be observed in a beaker job[3] where wget first tries to download the
puppet.deb file over ipv6

In most cases i think one just wants to have the docker image have a
ipv6 loopback and linklocal address which for reasons [4] docker dosn't
give us.  I  don't think anyone  actually needs a global IPv6
address.  As such adding something like the following to[5]
spec_helper_acceptance.rb[6] would produce the desired affect

  shell('sysctl net.ipv6.conf.all.disable_ipv6=0')

[1]https://tools.ietf.org/html/rfc3849
[2]https://docs.docker.com/config/daemon/ipv6/
[3]https://github.com/voxpupuli/puppet-unbound/runs/1595247379?check_suite_focus=true
(line 272)
[4]https://github.com/moby/moby/issues/33099
[5]https://github.com/voxpupuli/puppet-unbound/blob/master/spec/acceptance/unbound_spec.rb#L13
[6]https://github.com/voxpupuli/voxpupuli-acceptance/pull/16