### PR TITLE
moduleroot/Dockerfile.erb: use ruby:2.7

### DIFF
--- a/moduleroot/Dockerfile.erb
+++ b/moduleroot/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM ruby:2.5.3
+FROM ruby:2.7
 
 WORKDIR /opt/puppet
 


### PR DESCRIPTION
This will use the current version of Ruby 2.7.

This change was inspired by the one originally done here: https://github.com/voxpupuli/puppet-puppetboard/pull/309

Also, closes #699.