### PR TITLE
Install bundler2 for compatbility

### DIFF
--- a/moduleroot/Dockerfile.erb
+++ b/moduleroot/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM ruby:2.5.3
+FROM ruby:2.7.2
 
 WORKDIR /opt/puppet
 


### PR DESCRIPTION
As this Dockerfile copies module root, if there is a lock file created with bundler2 docker will keep failing with 

> Step 9/11 : RUN bundle install
>  ---> Running in 15086922f6ce
> You must use Bundler 2 or greater with this lockfile.
> The command '/bin/sh -c bundle install' returned a non-zero code: 20


After this PR Dockerfile should be working with lock files generated with both bundler1 and bundler2