### PR TITLE
changelog_generator: use upstream release

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -25,8 +25,7 @@ Gemfile:
       - gem: voxpupuli-acceptance
     ':release':
       - gem: github_changelog_generator
-        git: https://github.com/voxpupuli/github-changelog-generator
-        branch: voxpupuli_essential_fixes
+        version: '>= 1.16.1'
       - gem: puppet-blacksmith
       - gem: voxpupuli-release
       - gem: puppet-strings


### PR DESCRIPTION
After many months of waiting, upstream releases 1.16.0 (and a day after
1.16.1). It looks like those releases contain all features we require
  and I didn't notice any regressions.