### PR TITLE
Avoid test failures on CentOS caused by locale

### DIFF
--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -92,6 +92,8 @@ jobs:
       - name: Run tests
         run: bundle exec rake beaker
         env:
+          LANG: en_US
+          LC_ALL: en_US.UTF-8
           BEAKER_PUPPET_COLLECTION: ${{ matrix.puppet.collection }}
           BEAKER_setfile: ${{ matrix.setfile.value }}
           <%- @configs['beaker_fact_matrix'].keys.each do |fact| -%>


### PR DESCRIPTION
Setting en_US.UTF-8 prevents the builds from falling back to C, which
can break some tests for no good reason.

Observed with puppet-jira, at least.