### PR TITLE
Move all static validations to the setup job

### DIFF
--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -20,8 +20,8 @@ jobs:
         with:
           ruby-version: '2.7'
           bundler-cache: true
-      - name: Run rake validate
-        run: bundle exec rake validate
+      - name: Run static validations
+        run: bundle exec rake validate lint check
       - name: Run rake rubocop
         run: bundle exec rake rubocop
       - name: Setup Test Matrix
@@ -48,7 +48,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Run tests
-        run: bundle exec rake
+        run: bundle exec rake parallel_spec
 <%- if Dir[File.join(@metadata[:workdir], 'spec', 'acceptance', '**', '*_spec.rb')].any? -%>
 
   acceptance:


### PR DESCRIPTION
The default rake task is release_checks. This runs `lint`, `validate` prior to `parallel_spec` and ends with the `check` task. These static tasks shouldn't differ for the matrix job and can be run prior to running the whole test suite. Then in the actual test matrix, it only needs to run the tests (in parallel). This saves some CI resources when a static check fails.