### PR TITLE
Setup CI jobs on Ruby3 instead of Ruby 2.7

### DIFF
--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -18,7 +18,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.0'
           bundler-cache: true
       - name: Run static validations
         run: bundle exec rake validate lint check
@@ -87,7 +87,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.0'
           bundler-cache: true
       - name: Run tests
         run: bundle exec rake beaker


### PR DESCRIPTION
tested this in https://github.com/voxpupuli/puppet-collectd/pull/966