### PR TITLE
use latest github_changelog_generator release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :development do
 end
 
 group :release do
-  gem 'github_changelog_generator',  :require => false, :git => 'https://github.com/voxpupuli/github-changelog-generator', :branch => 'voxpupuli_essential_fixes'
+  gem 'github_changelog_generator',  :require => false
 end
 
 gem 'puppet_forge', '>= 2.2.9'


### PR DESCRIPTION
Since the last release, all of our required changes are merged.