### PR TITLE
Add a dummy test suite task to CI

### DIFF
--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -100,3 +100,14 @@ jobs:
           BEAKER_FACTER_<%= fact.upcase %>: ${{ matrix.<%= fact %> }}
           <%- end -%>
 <%- end -%>
+
+  tests:
+    needs:
+      - unit
+      <%- if Dir[File.join(@metadata[:workdir], 'spec', 'acceptance', '**', '*_spec.rb')].any? -%>
+      - acceptance
+      <%- end -%>
+    runs-on: ubuntu-latest
+    name: Test suite
+    steps:
+      - run: echo Test suite completed


### PR DESCRIPTION
This task is essentially a dummy but due to its dependencies it only completse if the entire test suite passed. This task can then be used as Github branch protection allowing the automerge feature to be used safely.

Tested in https://github.com/voxpupuli/puppet-example/pull/9