### PR TITLE
Limit to known-good setups from acceptance tests

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -18,7 +18,7 @@ Gemfile:
       - gem: coveralls
       - gem: simplecov-console
       - gem: puppet_metadata
-        version: '~> 0.3.0'
+        version: '~> 1.0'
     ':development':
       - gem: guard-rake
       - gem: overcommit

--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -12,9 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: <%= @configs['timeout_minutes'] %>
     outputs:
-      beaker_setfiles: ${{ steps.get-outputs.outputs.beaker_setfiles }}
-      puppet_major_versions: ${{ steps.get-outputs.outputs.puppet_major_versions }}
       puppet_unit_test_matrix: ${{ steps.get-outputs.outputs.puppet_unit_test_matrix }}
+      github_action_test_matrix: ${{ steps.get-outputs.outputs.github_action_test_matrix }}
     env:
       BUNDLE_WITHOUT: development:system_tests:release
     steps:
@@ -63,8 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        setfile: ${{fromJson(needs.setup_matrix.outputs.beaker_setfiles)}}
-        puppet: ${{fromJson(needs.setup_matrix.outputs.puppet_major_versions)}}
+        include: ${{fromJson(needs.setup_matrix.outputs.github_action_test_matrix)}}
         <%- @configs['beaker_fact_matrix'].each do |option, values| -%>
         <%= option %>:
         <%- values.each do |value| -%>


### PR DESCRIPTION
For acceptance testing, we look into `metadata.json` for supported versions of Puppet and operating systems, and for each combination try to execute the acceptance test suites.

However, some combination depend on nonexistent packages, typically for a recent version of Puppet on an old Linux distribution, or with an old version of Puppet on a recent Linux distribution.

Instead of letting GitHub compute all possible matrix combinations, rely
on puppet_metadata to build the list of supported combinations.

---

~~For checking, I opened https://github.com/voxpupuli/puppet-splunk/pull/314: compare with https://github.com/voxpupuli/puppet-splunk/pull/312 which had a bogus Puppet 5 on Ubuntu 20.04 test failing because no such package is available (on a side note, everything was broken and I had to add a commit to fix CI, but this is not related to _this_ change).~~

---

For checking, I opened https://github.com/voxpupuli/puppet-splunk/pull/315: compare with https://github.com/voxpupuli/puppet-splunk/pull/312 which had a bogus Puppet 5 on Ubuntu 20.04 test failing because no such package is available.