### PR TITLE
Delete legacy .yardopts

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -98,5 +98,7 @@ spec/spec_helper_acceptance.rb:
   unmanaged: true
 CONTRIBUTING.md:
   delete: true
+.yardopts:
+  delete: true
 ...
 # vim: syntax=yaml

--- a/moduleroot/.yardopts.erb
+++ b/moduleroot/.yardopts.erb
@@ -1,5 +1,2 @@
-# Managed by modulesync - DO NOT EDIT
-# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
-
 --markup markdown
 --output-dir docs/


### PR DESCRIPTION
I think we don't need thefile at the moment. We don't publish html docs
anymore, only the REFERENCE.md. `bundle exec rake reference` does not
require the .yardopts file. I tested this at https://github.com/voxpupuli/puppet-lldpd/pull/106

Fixes https://github.com/voxpupuli/modulesync_config/issues/733