### PR TITLE
Rakefile: Use `name` from metadata.json for GCG config.project

### DIFF
--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -52,7 +52,7 @@ begin
     config.header = "# Changelog\n\nAll notable changes to this project will be documented in this file.\nEach new release typically also includes the latest modulesync defaults.\nThese should not affect the functionality of the module."
     config.exclude_labels = %w{duplicate question invalid wontfix wont-fix modulesync skip-changelog}
     config.user = '<%= @configs['config.user'] -%>'
-    config.project = metadata.name
+    config.project = metadata.metadata['name']
   end
 
   # Workaround for https://github.com/github-changelog-generator/github-changelog-generator/issues/715


### PR DESCRIPTION
Fixes https://github.com/voxpupuli/modulesync_config/pull/730#discussion_r679144339
Tested at: https://github.com/voxpupuli/puppet-lldpd/pull/107