### PR TITLE
load puppet-blacksmith rake tasks if available

### DIFF
--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -23,6 +23,7 @@ end
 # only available if gem group releases is installed
 begin
   require 'voxpupuli/release/rake_tasks'
+  require 'puppet_blacksmith/rake_tasks'
 rescue LoadError
 end
 


### PR DESCRIPTION
without it the release group only provides:

```
$ bundle exec rake -T
rake changelog                   # Generate a Changelog from GitHub
rake check_changelog             # Check Changelog
rake reference[debug,backtrace]  # Generate REFERENCE.md
rake test_with_coveralls         # Run main 'test' task and report merged results to coveralls
rake travis_release              # release new version through Travis-ci
```

which is enough if we locally tag a release, but not enough for our CI
pipeline to build it. That step requires the module:push task. With
puppet-blacksmith we get:

```
$ bundle exec rake -T
rake changelog                               # Generate a Changelog from GitHub
rake check_changelog                         # Check Changelog
rake module:build                            # Build the module using puppet-modulebuilder
rake module:bump                             # Bump module version to the next patch
rake module:bump:full                        # Bump module version to the next FULL version
rake module:bump:major                       # Bump module version to the next MAJOR version
rake module:bump:minor                       # Bump module version to the next MINOR version
rake module:bump:patch                       # Bump module version to the next PATCH version
rake module:bump_commit                      # Bump version and git commit
rake module:bump_commit:full                 # Bump module version to the next FULL version and git commit
rake module:bump_commit:major                # Bump module version to the next MAJOR version and git commit
rake module:bump_commit:minor                # Bump module version to the next MINOR version and git commit
rake module:bump_commit:patch                # Bump module version to the next PATCH version and git commit
rake module:bump_to_version[new_version]     # Bump module to specific version number
rake module:clean                            # Runs clean again
rake module:dependency[module_name,version]  # Set specific module dependency version
rake module:push                             # Push module to the Puppet Forge
rake module:release                          # Release the Puppet module, doing a clean, build, bump_commit, tag, push and git push
rake module:tag                              # Git tag with the current module version
rake module:version                          # Get current module version
rake module:version:next                     # Get next module version
rake module:version:next:major               # Get the next MAJOR version
rake module:version:next:minor               # Get the next MINOR version
rake module:version:next:patch               # Get the next PATCH version
rake reference[debug,backtrace]              # Generate REFERENCE.md
rake test_with_coveralls                     # Run main 'test' task and report merged results to coveralls
rake travis_release                          # release new version through Travis-ci
```

I guess this worked previously because we always loaded
puppetlabs_spec_helper. This was introduced in https://github.com/voxpupuli/modulesync_config/pull/730/files#diff-3835bc2b05b86260141976bcf021f6261c0cea8e4a1e288f977268123e3b0c9cL35