### PR TITLE
cleanup puppet-blacksmith/voxpupuli-release dependencies

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -29,8 +29,8 @@ Gemfile:
     ':release':
       - gem: github_changelog_generator
         version: '>= 1.16.1'
-      - gem: puppet-blacksmith
       - gem: voxpupuli-release
+        version: '>= 1.0.2'
       - gem: puppet-strings
         version: '>= 2.2'
 Rakefile:


### PR DESCRIPTION
the voxpupuli-release 1.0.2 release depends on puppet-blacksmith, so we don't need to load it explicitly. Successor of https://github.com/voxpupuli/modulesync_config/pull/736. Tested in https://github.com/voxpupuli/puppet-lldpd/pull/109