### PR TITLE
Update EOL distros and Puppet version in clean-metadata

### DIFF
--- a/bin/clean-metadata
+++ b/bin/clean-metadata
@@ -3,18 +3,18 @@ import glob
 import json
 
 # Note range is exclusive so the last number is not in the list
-PUPPET_VERSION = '>= 5.5.8 < 7.0.0'
-UNSUPPORTED_EL = {str(i) for i in range(3, 6)}
+PUPPET_VERSION = '>= 6.1.0 < 8.0.0'
+UNSUPPORTED_EL = {str(i) for i in range(3, 7)}
 UNSUPPORTED = {
     'CentOS': UNSUPPORTED_EL,
-    'Debian': {str(i) for i in range(3, 8)},
-    'Fedora': {str(i) for i in range(3, 30)},
+    'Debian': {str(i) for i in range(3, 9)},
+    'Fedora': {str(i) for i in range(3, 33)},
     'OracleLinux': UNSUPPORTED_EL,
     'RedHat': UNSUPPORTED_EL,
     'SLED': {'9', '10'},
     'SLES': {'9', '10'},
     'Scientific': UNSUPPORTED_EL,
-    'Ubuntu': {str(i) + m for i in range(4, 18) for m in ('.04', '.10')} - {'16.04'},
+    'Ubuntu': {str(i) + m for i in range(4, 18) for m in ('.04', '.10')},
 }
 
 for filename in glob.glob('modules/*/*/metadata.json'):


### PR DESCRIPTION
By now a bunch of distributions went EOL. We've also moved to a new Puppet compatibility.