### PR TITLE
Add metadata_json_deps integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :release do
 end
 
 gem 'puppet_forge', '>= 2.2.9'
+gem 'metadata_json_deps', '~> 0.2.0'
 gem 'modulesync', '>= 1.0.0'
 gem "octokit", "~> 4.0"
 # vim: syntax=ruby

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+require 'metadata_json_deps'
+
+desc 'Run metadata-json-deps'
+task :metadata_deps do
+  files = FileList['modules/*/*/metadata.json']
+  MetadataJsonDeps.run(files)
+end


### PR DESCRIPTION
This makes it easy to check all dependencies in metadata.json. It goes well with ./bin/clean-git-checkouts.

```console
$ bundle exec rake metadata_deps
Checking modules/puppetlabs/puppetlabs-xinetd/metadata.json
Checking modules/voxpupuli/puppet-allknowingdns/metadata.json
  puppetlabs/stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-alternatives/metadata.json
Checking modules/voxpupuli/puppet-amanda/metadata.json
  puppetlabs/concat (>= 4.1.0 < 7.0.0) doesn't match 7.0.2
  puppetlabs/stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-appd_db_agent/metadata.json
  puppetlabs/stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
  puppetlabs/java (>= 1.5.0 < 5.0.0) doesn't match 7.0.2
  camptocamp/systemd (>= 1.0.0 < 3.0.0) doesn't match 3.0.0
Checking modules/voxpupuli/puppet-archive/metadata.json
Checking modules/voxpupuli/puppet-autofs/metadata.json
  puppetlabs/concat (>= 4.1.0 < 7.0.0) doesn't match 7.0.2
  puppetlabs/stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-bareos/metadata.json
  puppetlabs/apt (>= 2.0.0 < 8.0.0) doesn't match 8.1.0
  puppetlabs/concat (>= 4.1.0 < 7.0.0) doesn't match 7.0.2
  puppetlabs/stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-bird/metadata.json
Checking modules/voxpupuli/puppet-boolean/metadata.json
Checking modules/voxpupuli/puppet-borg/metadata.json
Checking modules/voxpupuli/puppet-caddy/metadata.json
  puppet/archive (>= 4.4.0 < 5.0.0) doesn't match 5.0.0
  puppetlabs/stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-cassandra/metadata.json
  puppetlabs-apt (>= 2.0.0 < 8.0.0) doesn't match 8.1.0
  puppetlabs-firewall (>= 1.0.0 < 3.0.0) doesn't match 3.1.0
  puppetlabs-inifile (>= 1.5.0 < 5.0.0) doesn't match 5.1.0
  puppetlabs-stdlib (>= 3.0.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-check_mk/metadata.json
  puppetlabs/concat (>= 4.1.0 < 7.0.0) doesn't match 7.0.2
  puppetlabs/stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
  camptocamp/systemd (>= 1.1.0 < 3.0.0) doesn't match 3.0.0
Checking modules/voxpupuli/puppet-chrony/metadata.json
Checking modules/voxpupuli/puppet-collectd/metadata.json
Checking modules/voxpupuli/puppet-community_kickstarts/metadata.json
  puppetlabs-stdlib (>= 4.6.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-confluence/metadata.json
  puppet/archive (>= 1.0.0 < 5.0.0) doesn't match 5.0.0
  puppetlabs/stdlib (>= 4.13.1 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-corosync/metadata.json
Checking modules/voxpupuli/puppet-cron/metadata.json
Checking modules/voxpupuli/puppet-dbbackup/metadata.json
Checking modules/voxpupuli/puppet-dhcp/metadata.json
  puppetlabs/concat (>= 4.1.0 < 7.0.0) doesn't match 7.0.2
  puppetlabs/stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-dotnet/metadata.json
  puppetlabs/stdlib (>= 4.6.0 < 7.0.0) doesn't match 7.1.0
  puppetlabs/powershell (>= 1.1.1 < 3.0.0) doesn't match 5.0.0
  puppet/download_file (>= 2.0.0 < 4.0.0) doesn't match 4.0.0
Checking modules/voxpupuli/puppet-download_file/metadata.json
  puppetlabs/stdlib (>= 4.13.1 < 7.0.0) doesn't match 7.1.0
  puppetlabs/powershell (>= 1.1.1 < 3.0.0) doesn't match 5.0.0
Checking modules/voxpupuli/puppet-drbd/metadata.json
  puppetlabs/concat (>= 4.1.0 < 7.0.0) doesn't match 7.0.2
  puppetlabs/stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-dropbear/metadata.json
  puppetlabs/stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-earlyoom/metadata.json
  puppetlabs-stdlib (>= 4.13.1 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-epel/metadata.json
Checking modules/voxpupuli/puppet-erlang/metadata.json
Checking modules/voxpupuli/puppet-etherpad/metadata.json
  puppetlabs-concat (>= 4.7.0 < 7.0.0) doesn't match 7.0.2
  puppetlabs-stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
  puppetlabs-vcsrepo (>= 1.3.1 < 4.0.0) doesn't match 5.0.0
  puppet-nodejs (>= 5.0.0 < 8.0.0) doesn't match 9.0.0
Checking modules/voxpupuli/puppet-example/metadata.json
  puppetlabs-stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-extlib/metadata.json
Checking modules/voxpupuli/puppet-facette/metadata.json
  puppetlabs/stdlib (>= 4.13.1 < 7.0.0) doesn't match 7.1.0
  herculesteam/augeasproviders_shellvar (>= 2.2.1 < 4.0.0) doesn't match 4.0.0
  puppetlabs/apt (>= 2.1.0 < 8.0.0) doesn't match 8.1.0
Checking modules/voxpupuli/puppet-fail2ban/metadata.json
  puppetlabs/stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-ferm/metadata.json
Checking modules/voxpupuli/puppet-fetchcrl/metadata.json
Checking modules/voxpupuli/puppet-filemapper/metadata.json
Checking modules/voxpupuli/puppet-firewalld/metadata.json
  puppetlabs/stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-gerrit/metadata.json
  puppetlabs/stdlib (>= 4.6.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-ghost/metadata.json
  puppetlabs/stdlib (>= 4.13.1 < 7.0.0) doesn't match 7.1.0
  puppet/nodejs (>= 1.3.0 < 7.0.0) doesn't match 9.0.0
Checking modules/voxpupuli/puppet-git_resource/metadata.json
Checking modules/voxpupuli/puppet-gitlab/metadata.json
Checking modules/voxpupuli/puppet-gitlab_ci_runner/metadata.json
  puppetlabs/concat (>= 6.3.0 < 7.0.0) doesn't match 7.0.2
  puppetlabs/stdlib (>= 4.13.0 < 7.0.0) doesn't match 7.1.0
  puppetlabs/apt (>= 6.3.0 < 8.0.0) doesn't match 8.1.0
Checking modules/voxpupuli/puppet-gluster/metadata.json
Checking modules/voxpupuli/puppet-googleauthenticator/metadata.json
Checking modules/voxpupuli/puppet-grafana/metadata.json
  puppetlabs/stdlib (>= 4.20.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-graphite_powershell/metadata.json
  puppetlabs/stdlib (>= 4.13.1 < 7.0.0) doesn't match 7.1.0
  puppet/download_file (>= 2.0.0 < 4.0.0) doesn't match 4.0.0
Checking modules/voxpupuli/puppet-groupmembership/metadata.json
Checking modules/voxpupuli/puppet-healthcheck/metadata.json
Checking modules/voxpupuli/puppet-hiera/metadata.json
  puppetlabs/stdlib (>= 4.13.1 < 7.0.0) doesn't match 7.1.0
  puppetlabs/inifile (>= 1.4.1 < 5.0.0) doesn't match 5.1.0
Checking modules/voxpupuli/puppet-homeassistant/metadata.json
  puppetlabs-stdlib (>= 4.10.0 < 7.0.0) doesn't match 7.1.0
  puppet-python (>= 2.2.2 < 3.0.0) doesn't match 6.1.0
Checking modules/voxpupuli/puppet-hyperglass/metadata.json
Checking modules/voxpupuli/puppet-ipset/metadata.json
Checking modules/voxpupuli/puppet-jail/metadata.json
Checking modules/voxpupuli/puppet-jenkins/metadata.json
  puppetlabs/stdlib (>= 4.19.0 < 7.0.0) doesn't match 7.1.0
  puppetlabs/apt (>= 4.4.0 < 8.0.0) doesn't match 8.1.0
  puppet/zypprepo (>= 2.0.0 < 3.0.0) doesn't match 4.0.0
  puppet/archive (>= 1.3.0 < 5.0.0) doesn't match 5.0.0
  camptocamp/systemd (>= 0.3.0 < 3.0.0) doesn't match 3.0.0
Checking modules/voxpupuli/puppet-jenkins_job_builder/metadata.json
  puppetlabs/stdlib (>= 4.13.1 < 7.0.0) doesn't match 7.1.0
  puppetlabs/inifile (>= 1.4.1 < 5.0.0) doesn't match 5.1.0
Checking modules/voxpupuli/puppet-jira/metadata.json
Checking modules/voxpupuli/puppet-jolokia/metadata.json
  puppetlabs-stdlib (>= 4.13.1 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-kafka/metadata.json
Checking modules/voxpupuli/puppet-keepalived/metadata.json
Checking modules/voxpupuli/puppet-ldapquery/metadata.json
Checking modules/voxpupuli/puppet-letsencrypt/metadata.json
  puppetlabs/stdlib (>= 4.13.1 < 7.0.0) doesn't match 7.1.0
  puppetlabs/inifile (>= 2.0.0 < 5.0.0) doesn't match 5.1.0
Checking modules/voxpupuli/puppet-lldpd/metadata.json
Checking modules/voxpupuli/puppet-logrotate/metadata.json
  puppetlabs/stdlib (>= 4.22.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-make/metadata.json
Checking modules/voxpupuli/puppet-mcollective/metadata.json
  puppetlabs/stdlib (>= 4.13.1 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-metche/metadata.json
  puppetlabs/stdlib (>= 4.13.1 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-minecraft/metadata.json
  puppetlabs-stdlib (>= 4.13.1 < 7.0.0) doesn't match 7.1.0
  puppetlabs-java (>= 1.6.0 < 5.0.0) doesn't match 7.0.2
Checking modules/voxpupuli/puppet-misp/metadata.json
  puppetlabs-stdlib (>= 4.19.0 < 6.0.0) doesn't match 7.1.0
  puppetlabs-vcsrepo (>= 1.3.2 < 3.0.0) doesn't match 5.0.0
Checking modules/voxpupuli/puppet-mlocate/metadata.json
Checking modules/voxpupuli/puppet-module/metadata.json
  puppetlabs/stdlib (>= 4.12.0 < 7.0.0) doesn't match 7.1.0
  puppetlabs/inifile (>= 1.3.0 < 5.0.0) doesn't match 5.1.0
Checking modules/voxpupuli/puppet-mongodb/metadata.json
  puppetlabs/apt (>= 2.1.0 < 8.0.0) doesn't match 8.1.0
  puppetlabs/stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-mosquitto/metadata.json
Checking modules/voxpupuli/puppet-mrepo/metadata.json
  puppetlabs/apache (>= 2.0.0 < 6.0.0) doesn't match 6.4.0
  puppetlabs/vcsrepo (>= 1.3.1 < 4.0.0) doesn't match 5.0.0
  puppetlabs/stdlib (>= 4.19.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-msoffice/metadata.json
  puppetlabs/stdlib (>= 4.6.0 < 7.0.0) doesn't match 7.1.0
  puppetlabs/powershell (>= 1.1.1 < 3.0.0) doesn't match 5.0.0
Checking modules/voxpupuli/puppet-mumble/metadata.json
  puppetlabs/apt (>= 2.1.0 < 8.0.0) doesn't match 8.1.0
  puppetlabs/stdlib (>= 4.13.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-mysql_java_connector/metadata.json
  puppetlabs-stdlib (>= 4.13.1 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-network/metadata.json
  puppetlabs/stdlib (>= 4.13.1 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-nginx/metadata.json
Checking modules/voxpupuli/puppet-nodejs/metadata.json
Checking modules/voxpupuli/puppet-nrpe/metadata.json
Checking modules/voxpupuli/puppet-nscd/metadata.json
  puppetlabs-stdlib (>= 4.13.1 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-nsclient/metadata.json
  puppetlabs/stdlib (>= 4.13.1 < 7.0.0) doesn't match 7.1.0
  puppet/download_file (>= 2.0.0 < 4.0.0) doesn't match 4.0.0
Checking modules/voxpupuli/puppet-nsd/metadata.json
Checking modules/voxpupuli/puppet-openvmtools/metadata.json
  puppetlabs/stdlib (>=2.3.0 <7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-openvpn/metadata.json
  puppetlabs/concat (>= 4.1.0 < 7.0.0) doesn't match 7.0.2
  puppetlabs/stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-pbuilder/metadata.json
  puppetlabs/concat (>=1.1.0 <7.0.0) doesn't match 7.0.2
  puppetlabs/stdlib (>=3.2.0 <7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-php/metadata.json
  puppet/zypprepo (>= 2.0.0 < 3.0.0) doesn't match 4.0.0
Checking modules/voxpupuli/puppet-pkgng/metadata.json
  puppetlabs/stdlib (>= 4.6.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-posix_acl/metadata.json
Checking modules/voxpupuli/puppet-poudriere/metadata.json
  puppetlabs/stdlib (>= 5.0.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-prometheus/metadata.json
Checking modules/voxpupuli/puppet-prometheus_reporter/metadata.json
Checking modules/voxpupuli/puppet-prosody/metadata.json
  puppetlabs/vcsrepo (>= 1.0.0 < 5.0.0) doesn't match 5.0.0
Checking modules/voxpupuli/puppet-proxysql/metadata.json
  puppetlabs-mysql (>= 2.5.0 < 12.0.0) doesn't match 12.0.0
Checking modules/voxpupuli/puppet-puppetboard/metadata.json
Checking modules/voxpupuli/puppet-pxe/metadata.json
  puppetlabs/concat (>= 4.1.0 < 7.0.0) doesn't match 7.0.2
  puppetlabs/stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-python/metadata.json
Checking modules/voxpupuli/puppet-r10k/metadata.json
Checking modules/voxpupuli/puppet-rabbitmq/metadata.json
Checking modules/voxpupuli/puppet-redis/metadata.json
Checking modules/voxpupuli/puppet-rhsm/metadata.json
  puppetlabs-stdlib (>= 4.18.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-rkhunter/metadata.json
  puppetlabs/stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-rsyslog/metadata.json
  puppetlabs-apt (>= 5.0.0 < 8.0.0) doesn't match 8.1.0
  puppetlabs-concat (>= 4.1.0 < 7.0.0) doesn't match 7.0.2
  puppetlabs-stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-rundeck/metadata.json
  puppetlabs/stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
  puppetlabs/inifile (>= 1.4.1 < 5.0.0) doesn't match 5.1.0
  puppet/archive (>= 1.0.0 < 5.0.0) doesn't match 5.0.0
  puppetlabs/java_ks (>= 1.3.1 < 4.0.0) doesn't match 4.1.0
Checking modules/voxpupuli/puppet-rvm/metadata.json
Checking modules/voxpupuli/puppet-selinux/metadata.json
Checking modules/voxpupuli/puppet-sftp_jail/metadata.json
  saz/ssh (>= 2.9.1 < 7.0.0) doesn't match 7.0.0
  puppetlabs/stdlib (>= 4.13.1 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-smokeping/metadata.json
  puppetlabs/apache (>= 1.6.0 < 6.0.0) doesn't match 6.4.0
  puppetlabs/concat (>= 4.1.0 < 7.0.0) doesn't match 7.0.2
  puppetlabs/firewall (>= 1.7.0 < 3.0.0) doesn't match 3.1.0
  puppetlabs/stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-snmp/metadata.json
Checking modules/voxpupuli/puppet-spiped/metadata.json
Checking modules/voxpupuli/puppet-splunk/metadata.json
  puppetlabs-stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
  puppetlabs-inifile (>= 1.4.1 < 5.0.0) doesn't match 5.1.0
  puppetlabs-concat (>= 4.2.1 < 7.0.0) doesn't match 7.0.2
Checking modules/voxpupuli/puppet-squid/metadata.json
  puppetlabs-concat (>= 1.2.5 < 7.0.0) doesn't match 7.0.2
  puppetlabs-stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-ssh_keygen/metadata.json
Checking modules/voxpupuli/puppet-sslcertificate/metadata.json
  puppetlabs/stdlib (>= 4.13.1 < 7.0.0) doesn't match 7.1.0
  puppetlabs/powershell (>= 1.1.1 < 3.0.0) doesn't match 5.0.0
Checking modules/voxpupuli/puppet-stackify/metadata.json
  puppetlabs-stdlib (>= 4.13.1 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-staging/metadata.json
Checking modules/voxpupuli/puppet-stash/metadata.json
  puppetlabs/inifile (>= 1.4.1 < 5.0.0) doesn't match 5.1.0
  puppetlabs/stdlib (>= 4.13.1 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-strongswan/metadata.json
  puppetlabs-concat (>= 4.1.0 < 7.0.0) doesn't match 7.0.2
  puppetlabs-stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-system/metadata.json
  puppetlabs-concat (>= 4.1.0 < 7.0.0) doesn't match 7.0.2
  puppetlabs-stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-tea/metadata.json
Checking modules/voxpupuli/puppet-telegraf/metadata.json
Checking modules/voxpupuli/puppet-trusted_ca/metadata.json
Checking modules/voxpupuli/puppet-tvheadend/metadata.json
  puppetlabs/apt (>= 2.1.0 < 8.0.0) doesn't match 8.1.0
  puppetlabs/concat (>= 4.1.0 < 7.0.0) doesn't match 7.0.2
  puppetlabs/stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
  stm/debconf (>= 2.0.0 < 3.0.0) doesn't match 3.3.1
  herculesteam/augeasproviders_core (>= 2.1.0 < 3.0.0) doesn't match 3.0.0
  herculesteam/augeasproviders_shellvar (>= 2.2.1 < 4.0.0) doesn't match 4.0.0
Checking modules/voxpupuli/puppet-unattended_upgrades/metadata.json
Checking modules/voxpupuli/puppet-unbound/metadata.json
Checking modules/voxpupuli/puppet-vault_lookup/metadata.json
Checking modules/voxpupuli/puppet-virtualbox/metadata.json
  puppetlabs/stdlib (>= 4.13.1 < 7.0.0) doesn't match 7.1.0
  puppetlabs/apt (>= 2.1.0 < 8.0.0) doesn't match 8.1.0
Checking modules/voxpupuli/puppet-visualstudio/metadata.json
  puppetlabs/stdlib (>= 4.13.1 < 7.0.0) doesn't match 7.1.0
  puppetlabs/powershell (>= 1.1.1 < 3.0.0) doesn't match 5.0.0
Checking modules/voxpupuli/puppet-wget/metadata.json
Checking modules/voxpupuli/puppet-windows_autoupdate/metadata.json
  puppetlabs/stdlib (>= 4.6.0 < 7.0.0) doesn't match 7.1.0
  puppetlabs/registry (>= 1.1.1 < 3.0.0) doesn't match 4.0.0
Checking modules/voxpupuli/puppet-windows_env/metadata.json
Checking modules/voxpupuli/puppet-windows_eventlog/metadata.json
  puppetlabs/stdlib (>= 4.6.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-windows_firewall/metadata.json
  puppetlabs/stdlib (>= 4.25.1 < 7.0.0) doesn't match 7.1.0
  puppetlabs/registry (>= 1.1.1 < 4.0.0) doesn't match 4.0.0
Checking modules/voxpupuli/puppet-windows_power/metadata.json
  puppetlabs/stdlib (>= 4.6.0 < 7.0.0) doesn't match 7.1.0
  puppetlabs/powershell (>= 1.0.5 < 3.0.0) doesn't match 5.0.0
Checking modules/voxpupuli/puppet-windowsfeature/metadata.json
Checking modules/voxpupuli/puppet-winlogbeat/metadata.json
  puppetlabs-powershell (>= 1.0.1 < 5.0.0) doesn't match 5.0.0
  puppetlabs-stdlib (>= 4.6.0 < 7.0.0) doesn't match 7.1.0
Checking modules/voxpupuli/puppet-xmlfile/metadata.json
Checking modules/voxpupuli/puppet-yum/metadata.json
Checking modules/voxpupuli/puppet-zabbix/metadata.json
  puppetlabs/mysql (>= 3.5.0 < 12.0.0) doesn't match 12.0.0
Checking modules/voxpupuli/puppet-zypprepo/metadata.json
```