### PR TITLE
puppet_metadata: Require 1.x

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -18,7 +18,7 @@ Gemfile:
       - gem: coveralls
       - gem: simplecov-console
       - gem: puppet_metadata
-        version: '~> 0.3.0'
+        version: '~> 1.0'
     ':development':
       - gem: guard-rake
       - gem: overcommit


### PR DESCRIPTION
This change is tested here:
https://github.com/voxpupuli/puppet-borg/pull/117/