### PR TITLE
Limit github_changelog_generator to Ruby 2.5+

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -29,6 +29,8 @@ Gemfile:
     ':release':
       - gem: github_changelog_generator
         version: '>= 1.16.1'
+        ruby-version: '2.5'
+        ruby-operator: '>='
       - gem: voxpupuli-release
         version: '>= 1.0.2'
       - gem: puppet-strings


### PR DESCRIPTION
This keeps it possible to test on Puppet 5.