### PR TITLE
metadata_json_deps: Allow 1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :release do
 end
 
 gem 'puppet_forge', '>= 2.2.9'
-gem 'metadata_json_deps', '~> 0.2.0'
+gem 'metadata_json_deps', '>= 0.2.0', '< 2'
 gem 'modulesync', '>= 1.0.0'
 gem "octokit", "~> 4.0"
 # vim: syntax=ruby


### PR DESCRIPTION
this allows msync and our scripts to run with latest Dependencies. I added the skip-changelog because this only effects our setup, not the modules.