### PR TITLE
Cancel in-progress/pending workflows of the same branch

### DIFF
--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -6,6 +6,10 @@ name: CI
 
 on: pull_request
 
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   setup_matrix:
     name: 'Setup Test Matrix'


### PR DESCRIPTION
[Concurrency setting documentation](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency).

This PR introduces a Travis-like behavior which was cancelling any previous jobs when new changes were pushed.
This can help with modules whose acceptance tests are time consuming and stacking up workflows can lead to hit the concurrency limit pretty quickly.

A example could be the [voxpupuli/puppet-zabbix](https://github.com/voxpupuli/puppet-zabbix) module whose acceptance tests are lasting up to an hour, if a contributor pushes 5 changes we end up with ~60 jobs in the queue.

Caveats:

* This setting is currently in beta and maybe we don't want to merge it to our modulesync just yet

I haven't thought of all the cons of this change, so I'm open to discussion :smile: