### PR TITLE
Archive the facette module

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -31,7 +31,6 @@
 - puppet-etherpad
 - puppet-example
 - puppet-extlib
-- puppet-facette
 - puppet-fail2ban
 - puppet-ferm
 - puppet-fetchcrl


### PR DESCRIPTION
Quoting https://github.com/voxpupuli/puppet-facette/issues/56

> As explained in \#51 this module only make sense on EOL platforms and
> maintaining it does not make sense anymore in it current shape.
>
> This is a proposal to archive this module.
