### PR TITLE
voxpupuli-test: Require 4.x instead of 3.x

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -14,7 +14,7 @@ Gemfile:
   required:
     ':test':
       - gem: voxpupuli-test
-        version: '~> 3.0'
+        version: '~> 4.0'
       - gem: coveralls
       - gem: simplecov-console
       - gem: puppet_metadata


### PR DESCRIPTION
This pulls in new versions of puppetlabs_spec_helper and newer rubocop.