### PR TITLE
puppet-lint: fail on warnings

### DIFF
--- a/moduleroot/.puppet-lint.rc.erb
+++ b/moduleroot/.puppet-lint.rc.erb
@@ -1,3 +1,4 @@
+--fail-on-warnings
 <% checks = @configs['disabled_lint_checks'] - @configs['enabled_lint_checks'] -%>
 <% checks.each do |check| -%>
 --no-<%= check.sub(/^disable_/, '') %>-check


### PR DESCRIPTION
this worked previously, probably because an older version of
puppetlabs_spec_helper enabled it.