### PR TITLE
swap puppet-lint-param-types with puppet-lint-parameter_type-check

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -41,7 +41,7 @@ Rakefile:
 .puppet-lint.rc:
   disabled_lint_checks:
     - parameter_documentation
-    - parameter_type
+    - parameter_types
   enabled_lint_checks: []
 spec/default_facts.yml:
   delete: true


### PR DESCRIPTION
I mixed up the two puppet-lint plugins. What we want to use is
puppet-lint-param-types. That works with custom datatypes as well. Their
check is called `parameter_types`:
https://github.com/hostnet/puppet-lint-param-types/blob/master/lib/puppet-lint/plugins/check_parameter_types.rb#L1