### PR TITLE
Switch to github.ref_name for concurrency group

### DIFF
--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -7,7 +7,7 @@ name: CI
 on: pull_request
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
`github.head_ref` exists only on Pull Requests. This can cause problems
e.g if we want to run the CI nightly on a cron job. `github.ref_name`
seems to be the same thing.