### PR TITLE
Align module repository with module name

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -40,7 +40,7 @@
 - puppet-drbd
 - puppet-dropbear
 - puppet-earlyoom
-- puppet-elastic-stack
+- puppet-elastic_stack
 - puppet-elasticsearch
 - puppet-epel
 - puppet-erlang


### PR DESCRIPTION
The repository was renamed to match the module name.  Use the new URL.