### PR TITLE
CONTRIBUTING.md: correct example, update OSes

### DIFF
--- a/moduleroot/.github/CONTRIBUTING.md.erb
+++ b/moduleroot/.github/CONTRIBUTING.md.erb
@@ -232,17 +232,16 @@ simple tests against it after applying the module. You can run this
 with:
 
 ```sh
-BEAKER_setfile=debian10-x64 bundle exec rake beaker
+BEAKER_setfile=debian11-64 bundle exec rake beaker
 ```
 
 You can replace the string `debian10` with any common operating system.
 The following strings are known to work:
 
-* ubuntu1604
 * ubuntu1804
 * ubuntu2004
-* debian9
 * debian10
+* debian11
 * centos7
 * centos8
 


### PR DESCRIPTION
There should be no "x" before the "64" in the `setfile` name.