### PR TITLE
Add support for local rubocop overrides

### DIFF
--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -4,3 +4,6 @@
 
 inherit_gem:
   voxpupuli-test: rubocop.yml
+<% if @configs['extra'] -%>
+<%= @configs['extra'].to_yaml.sub(/\A---\n/, '') -%>
+<% end -%>


### PR DESCRIPTION
All module rubocop configuration is provided by the voxpupuli-test which
provide sensible defaults.  Some modules may however benefit from
overriding some configuration, for example in the LDAP language, a
*distinguished name* is often referred to as *dn* but this 2 letters
variable name will make rubocop choke on the 3 letters minimum for a
variable name test.  A similar issue exist with types and providers
where the Puppet documentation use the *is* and *should* variables to
compare current and expected states, the former variable name not
matching this rule.

Allow fine tunning the rules when to add this kind of exceptions.
