### PR TITLE
Drop puppet-boolean

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -21,7 +21,6 @@
 - puppet-autofs
 - puppet-bareos
 - puppet-bird
-- puppet-boolean
 - puppet-borg
 - puppet-caddy
 - puppet-cassandra


### PR DESCRIPTION
Per https://github.com/voxpupuli/puppet-boolean/issues/34 this module should be deprecated.