### PR TITLE
Adding puppet-falco to the list of managed modules

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -47,6 +47,7 @@
 - puppet-example
 - puppet-extlib
 - puppet-fail2ban
+- puppet-falco
 - puppet-ferm
 - puppet-fetchcrl
 - puppet-filemapper


### PR DESCRIPTION
This PR should be good to go once the module's repo has been renamed from `genebean-falco` to `puppet-falco`.