### PR TITLE
voxpupuli-test: Pull in 5.4 or newer

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -13,7 +13,7 @@ Gemfile:
   required:
     ':test':
       - gem: voxpupuli-test
-        version: '~> 5.0'
+        version: '~> 5.4'
       - gem: coveralls
       - gem: simplecov-console
       - gem: puppet_metadata


### PR DESCRIPTION
This ensures that people testing locally have the same rubocop as our
CI. People complained in the past that CI shows issues they cannot
reproproduce. This changes forces them to run `bundle update` and will
then pull in latest rubocop.