### PR TITLE
Explicitly require YAML in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,7 @@ end
 
 begin
   require 'github_changelog_generator/task'
+  require 'yaml'
 
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     config.header = "# Changelog\n\nAll notable changes to this project will be documented in this file."


### PR DESCRIPTION
Previously it was relying on other gems to pull in YAML while using it a bit lower. This makes it explicit which at worst is redundant and at best prevents failures. It is loaded after github_changelog_generator so that if the gem isn't present, YAML isn't pulled in either.

Fixes #784