### PR TITLE
Update REFERENCE.md during CHANGELOG.md creation

### DIFF
--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -55,6 +55,11 @@ begin
     config.project = metadata.metadata['name']
   end
 
+  # update the REFERENCE.md if it exists
+  # reference task will run before changelog
+  # https://dev.to/molly/rake-task-enhance-method-explained-3bo0
+  Rake::Task['changelog'].enhance(['reference']) if File.exist?('REFERENCE.md')
+
   # Workaround for https://github.com/github-changelog-generator/github-changelog-generator/issues/715
   require 'rbconfig'
   if RbConfig::CONFIG['host_os'] =~ /linux/
@@ -66,7 +71,6 @@ begin
       File.open(changelog_file, "w") {|file| file.puts new_contents }
     end
   end
-
 rescue LoadError
 end
 # vim: syntax=ruby


### PR DESCRIPTION
At the moment our release rake tasks checks if the REFERENCE.md is
up2date. It doesn't update it. I think it makes sense to generate the
REFERENCE.md in the same step as the CHANGELOG.md, because that will be
reviewed in a PR. This commit implements it. I created
https://github.com/voxpupuli/puppet-logrotate/pull/201 to check if
rubocop is happy.