### PR TITLE
Rework release preparation tasks

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -32,11 +32,11 @@ Gemfile:
         ruby-version: '2.5'
         ruby-operator: '>='
       - gem: voxpupuli-release
-        version: '>= 1.2.0'
-      - gem: puppet-strings
-        version: '>= 2.2'
+        version: '~> 2.0'
 Rakefile:
-  puppet_strings_patterns: []
+  # config.user: USER
+  # config.project: PROJECT
+  # config.tag_pattern: 'v%s'
 .puppet-lint.rc:
   disabled_lint_checks:
     - parameter_documentation

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -24,6 +24,13 @@ end
 begin
   require 'voxpupuli/release/rake_tasks'
 rescue LoadError
+  # voxpupuli-release not present
+else
+  GCGConfig.user = '<%= @configs['config.user'] || @configs[:namespace] %>'
+  GCGConfig.project = '<%= @configs['config.project'] || @configs[:puppet_module] %>'
+  <%- if @configs['config.tag_pattern'] -%>
+  GCGConfig.tag_pattern = '<%= @configs['config.tag_pattern'] -%>'
+  <%- end -%>
 end
 
 desc "Run main 'test' task and report merged results to coveralls"
@@ -37,36 +44,4 @@ task test_with_coveralls: [:test] do
   end
 end
 
-desc 'Generate REFERENCE.md'
-task :reference, [:debug, :backtrace] do |t, args|
-  patterns = '<%= @configs['puppet_strings_patterns'].join(" ") %>'
-  Rake::Task['strings:generate:reference'].invoke(patterns, args[:debug], args[:backtrace])
-end
-
-begin
-  require 'github_changelog_generator/task'
-  require 'puppet_blacksmith'
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    metadata = Blacksmith::Modulefile.new
-    config.future_release = "v#{metadata.version}" if metadata.version =~ /^\d+\.\d+.\d+$/
-    config.header = "# Changelog\n\nAll notable changes to this project will be documented in this file.\nEach new release typically also includes the latest modulesync defaults.\nThese should not affect the functionality of the module."
-    config.exclude_labels = %w{duplicate question invalid wontfix wont-fix modulesync skip-changelog}
-    config.user = '<%= @configs['config.user'] || @configs[:namespace] %>'
-    config.project = '<%= @configs['config.project'] || @configs[:puppet_module] %>'
-  end
-
-  # Workaround for https://github.com/github-changelog-generator/github-changelog-generator/issues/715
-  require 'rbconfig'
-  if RbConfig::CONFIG['host_os'] =~ /linux/
-    task :changelog do
-      puts 'Fixing line endings...'
-      changelog_file = File.join(__dir__, 'CHANGELOG.md')
-      changelog_txt = File.read(changelog_file)
-      new_contents = changelog_txt.gsub(%r{\r\n}, "\n")
-      File.open(changelog_file, "w") {|file| file.puts new_contents }
-    end
-  end
-
-rescue LoadError
-end
 # vim: syntax=ruby


### PR DESCRIPTION
This is a follow-up to https://github.com/voxpupuli/modulesync_config/pull/788

Voxpupuli contributors used to update a module version and `rake changelog` before openning a PR for preparing a new release.  Some modules now have a REFERENCE.md file that also needs to be updated (by running `rake reference`), and forgetting to do so will remained unnoticed until `rake release` complain that the file is not up-to-date (so after the release PR was reviewed and merged).

This PR remove the `changelog` and `reference` tasks which are now part of the voxpupuli-release gem.
