### PR TITLE
anchor most .pmtignore patterns to the root of the module

### DIFF
--- a/moduleroot/.pmtignore.erb
+++ b/moduleroot/.pmtignore.erb
@@ -1,40 +1,40 @@
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
-docs/
-pkg/
-Gemfile
-Gemfile.lock
-Gemfile.local
-vendor/
-.vendor/
-spec/
-Rakefile
-.vagrant/
-.bundle/
-.ruby-version
-coverage/
-log/
-.idea/
-.dependencies/
-.github/
-.librarian/
-Puppetfile.lock
+/docs/
+/pkg/
+/Gemfile
+/Gemfile.lock
+/Gemfile.local
+/vendor/
+/.vendor/
+/spec/
+/Rakefile
+/.vagrant/
+/.bundle/
+/.ruby-version
+/coverage/
+/log/
+/.idea/
+/.dependencies/
+/.github/
+/.librarian/
+/Puppetfile.lock
 *.iml
-.editorconfig
-.fixtures.yml
-.gitignore
-.msync.yml
-.overcommit.yml
-.pmtignore
-.rspec
-.rspec_parallel
-.rubocop.yml
-.sync.yml
+/.editorconfig
+/.fixtures.yml
+/.gitignore
+/.msync.yml
+/.overcommit.yml
+/.pmtignore
+/.rspec
+/.rspec_parallel
+/.rubocop.yml
+/.sync.yml
 .*.sw?
-.yardoc/
-.yardopts
-Dockerfile
+/.yardoc/
+/.yardopts
+/Dockerfile
 <% if ! @configs['paths'].nil? -%>
 <% @configs['paths'].each do |path| -%>
 <%= path %>


### PR DESCRIPTION
The PathSpec used by .pmtignore will match all recursive directories
unless there is a "separator" at the start of the pattern per
https://git-scm.com/docs/gitignore.

As an example of the problem, the pattern `log/` will match a dir named
`foo/log`. Prefixing the pattern with `/` forces the pattern to match
only relative to the root of the module. Where as the pattern `/log/`
would not match a dir named `foo/log`.