### PR TITLE
Allow opting-out of GitHub Action acceptance tests

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -4,6 +4,7 @@
   excludes: []
   pidfile_workaround: false
   additional_packages: ''
+  acceptance_tests: true
 .travis.yml:
   delete: true
 Jenkinsfile:

--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   puppet:
     name: Puppet
-<%- if Dir[File.join(@metadata[:workdir], 'spec', 'acceptance', '**', '*_spec.rb')].any? -%>
+<%- if @configs['acceptance_tests'] && Dir[File.join(@metadata[:workdir], 'spec', 'acceptance', '**', '*_spec.rb')].any? -%>
     uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v1
     with:
       pidfile_workaround: '<%= @configs['pidfile_workaround'] %>'


### PR DESCRIPTION
Some modules acceptance tests cannot be run from a docker container as exposed by GitHub Actions (e.g. the puppet-virtualbox module want to install the running kernel headers to build kernel modules (which is not possible if the kernel of the host system is not one of the kernels available in the test system), and then load modules in the kernel which is not allowed.

Add a configuration flag `acceptance_tests` (defaulting to true) and make modulesync check it before emitting the suitable GitHub Actions for the module.
