### PR TITLE
Add puppet-puppet_certificate

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -123,6 +123,7 @@
 - puppet-prosody
 - puppet-puppetboard
 - puppet-puppetwebhook
+- puppet-puppet_certificate
 - puppet-puppet_summary
 - puppet-pxe
 - puppet-python


### PR DESCRIPTION
Note, I'll need to come up with a custom `.sync.yml` before anyone runs the modulesync as I want a release with older agent compatibility before going to town with usual rubocop rules etc.