### PR TITLE
puppet-strings: require 4.x

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -36,6 +36,8 @@ Gemfile:
         version: '~> 2.0'
       - gem: faraday-retry
         version: '~> 2.1'
+      - gem: puppet-strings
+        version: '~> 4.0'
 Rakefile:
   # config.user: USER
   # config.project: PROJECT


### PR DESCRIPTION
puppet-strings 3 changed how links in markdown are represented. To not cause a lot of noise with puppet-strings 2 vs 3, we should enforce we're on puppet-strings 3.