### PR TITLE
Delete old code of conducts

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -131,5 +131,9 @@ pdk.yaml:
   delete: true
 .tool-versions:
   delete: true
+CODE_OF_CONDUCT.md:
+  delete: true
+.github/CODE_OF_CONDUCT.md:
+  delete: true
 ...
 # vim: syntax=yaml


### PR DESCRIPTION
They aren't required anymore when we've an org-wide CoC published: https://github.com/voxpupuli/.github/pull/2