### PR TITLE
Allow configuring RuboCop in CI

### DIFF
--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -17,13 +17,15 @@ jobs:
     uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v1
     with:
       pidfile_workaround: '<%= @configs['pidfile_workaround'] %>'
-<%- unless @configs['additional_packages'].empty? -%>
-      additional_packages: '<%= @configs['additional_packages'] %>'
-<%- end -%>
 <%- else -%>
     uses: voxpupuli/gha-puppet/.github/workflows/basic.yml@v1
-<%- unless @configs['additional_packages'].empty? -%>
+<%- if @configs.key?('rubocop') || !@configs['additional_packages'].empty? -%>
     with:
+<%- end -%>
+<%- end -%>
+<%- unless @configs['additional_packages'].empty? -%>
       additional_packages: '<%= @configs['additional_packages'] %>'
 <%- end -%>
+<%- if @configs.key?('rubocop') -%>
+      rubocop: <%= @configs['rubocop'] %>
 <%- end -%>


### PR DESCRIPTION
When migrating modules it can be a lot easier to disable RuboCop in the first PR and then take care of it later.