### PR TITLE
Purge legacy Modulefile in modules

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -139,5 +139,7 @@ SECURITY.md:
   delete: true
 .github/SECURITY.md:
   delete: true
+Modulefile:
+  delete: true
 ...
 # vim: syntax=yaml


### PR DESCRIPTION
`Modulefile` was the metadata.json predecessor. It's deprecated and none of our modules should have it.