### PR TITLE
Drop PDK created puppet-lint GHA workflow

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -5,6 +5,9 @@
   pidfile_workaround: false
   additional_packages: ''
   acceptance_tests: true
+# PDK creates this
+.github/workflows/puppet-lint.yml:
+  delete: true
 .travis.yml:
   delete: true
 Jenkinsfile:


### PR DESCRIPTION
When converting from PDK this file should be cleaned up, since we run puppet-lint in our primary CI action.