### PR TITLE
Remove template for `.yardopts`

### DIFF
--- a/moduleroot/.yardopts.erb
+++ b/moduleroot/.yardopts.erb
@@ -1,2 +1,0 @@
---markup markdown
---output-dir docs/


### PR DESCRIPTION
We ensure the file is removed in `config_defaults.yml`, so no need to
manage its content.
