### PR TITLE
Add faraday-retry to release gem group

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -36,6 +36,10 @@ Gemfile:
         ruby-operator: '>='
       - gem: voxpupuli-release
         version: '~> 2.0'
+      - gem: faraday-retry
+        version: '~> 2.1'
+        ruby-version: '2.6'
+        ruby-operator: '>='
 Rakefile:
   # config.user: USER
   # config.project: PROJECT


### PR DESCRIPTION
This is an optional requirement for the changelog generator. GCG throws a warning when the gem is missing. Test PR: https://github.com/voxpupuli/puppet-example/pull/31