### PR TITLE
Gemfile: Pin to Puppet ~> 7.24

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -13,7 +13,7 @@
 Jenkinsfile:
   delete: true
 Gemfile:
-  puppet_version: '>= 6.0'
+  puppet_version: '~> 7.24'
   required:
     ':test':
       - gem: voxpupuli-test


### PR DESCRIPTION
This is the first step to deprecate puppet 6. We raise the default puppet version in the Gemfile in our modules. also we limit it to 7.x so we don't pull in puppet 8 by accident. And we pin to 7.24 or newer to prevent issues with ruby-concurrent.