### PR TITLE
Add management of the newly transfered SSSD module

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -149,6 +149,7 @@
 - puppet-splunk
 - puppet-squid
 - puppet-ssh_keygen
+- puppet-sssd
 - puppet-stackify
 - puppet-stash
 - puppet-strongswan


### PR DESCRIPTION
I've transferred over https://github.com/voxpupuli/puppet-sssd

Per https://github.com/sgnl05/sgnl05-sssd/issues/102#issuecomment-1645381857

This module was originally developed with PDK so it may require a few tweaks to get shifted into modulesync.  Or it may not.