### PR TITLE
Cleanup release gem group for modules

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -30,12 +30,8 @@ Gemfile:
       - gem: voxpupuli-acceptance
         version: '~> 2.0'
     ':release':
-      - gem: github_changelog_generator
-        version: '>= 1.16.1'
       - gem: voxpupuli-release
         version: '~> 3.0'
-      - gem: faraday-retry
-        version: '~> 2.1'
 Rakefile:
   # config.user: USER
   # config.project: PROJECT


### PR DESCRIPTION
since voxpupuli-release 3.0.1 it pulls in github_changelog_generator and faraday. We don't need to declare it in our Gemfile again.