### PR TITLE
Update to gha-puppet v2

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -21,14 +21,14 @@ Gemfile:
       - gem: coveralls
       - gem: simplecov-console
       - gem: puppet_metadata
-        version: '~> 3.0'
+        version: '~> 3.5'
     ':development':
       - gem: guard-rake
       - gem: overcommit
         version: '>= 0.39.1'
     ':system_tests':
       - gem: voxpupuli-acceptance
-        version: '~> 2.0'
+        version: '~> 2.2'
     ':release':
       - gem: voxpupuli-release
         version: '~> 3.0'

--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -14,7 +14,7 @@ jobs:
   puppet:
     name: Puppet
 <%- if @configs['acceptance_tests'] && Dir[File.join(@metadata[:workdir], 'spec', 'acceptance', '**', '*_spec.rb')].any? -%>
-    uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v1
+    uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v2
     with:
       pidfile_workaround: '<%= @configs['pidfile_workaround'] %>'
 <%- if @configs['unit_runs_on'] -%>
@@ -24,7 +24,7 @@ jobs:
       acceptance_runs_on: '<%= @configs['acceptance_runs_on'] %>'
 <%- end -%>
 <%- else -%>
-    uses: voxpupuli/gha-puppet/.github/workflows/basic.yml@v1
+    uses: voxpupuli/gha-puppet/.github/workflows/basic.yml@v2
 <%- if @configs.key?('rubocop') || !@configs['additional_packages'].empty? || @configs.key?('unit_runs_on') -%>
     with:
 <%- end -%>

--- a/moduleroot/.github/workflows/release.yml.erb
+++ b/moduleroot/.github/workflows/release.yml.erb
@@ -12,7 +12,7 @@ on:
 jobs:
   release:
     name: Release
-    uses: voxpupuli/gha-puppet/.github/workflows/release.yml@v1
+    uses: voxpupuli/gha-puppet/.github/workflows/release.yml@v2
     with:
       allowed_owner: '<%= @configs[:namespace] %>'
     secrets:


### PR DESCRIPTION
This updates to gha-puppet v2 and raises minimum gem versions so it can support non-AIO Debian 12 testing.