### PR TITLE
add support for arbitrary `with` values for beaker.yml workflow

### DIFF
--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -22,6 +22,9 @@ jobs:
 <%- if @configs['acceptance_tests'] && Dir[File.join(@metadata[:workdir], 'spec', 'acceptance', '**', '*_spec.rb')].any? -%>
     uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v2
     with:
+<%-   if @configs['with'] -%>
+<%=     @configs['with'].to_yaml.split("\n")[1..-1].join.gsub(/^/, ' ' * 6) %>
+<%-   end -%>
       pidfile_workaround: '<%= @configs['pidfile_workaround'] %>'
 <%- if @configs['unit_runs_on'] -%>
       unit_runs_on: '<%= @configs['unit_runs_on'] %>'


### PR DESCRIPTION
Example `.sync.yml` snippet:

    .github/workflows/ci.yml:
       with:
         hosts: master,replica,client

Related to:
- https://github.com/voxpupuli/puppet_metadata/pull/111
- https://github.com/voxpupuli/gha-puppet/pull/46