### PR TITLE
Delete legacy Makefile

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -142,5 +142,7 @@ SECURITY.md:
   delete: true
 Modulefile:
   delete: true
+Makefile:
+  delete: true
 ...
 # vim: syntax=yaml


### PR DESCRIPTION
We have a few modules with legacy Makefiles:

```
$ ls puppet-*/Makefile
puppet-consul/Makefile            puppet-logstash/Makefile
puppet-gitlab_ci_runner/Makefile  puppet-spiped/Makefile
```

Those Makefiles try to run old tests. They don't work anymore. We can delete them.