### PR TITLE
Also run CI an the main/master branch

### DIFF
--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -4,7 +4,12 @@
 
 name: CI
 
-on: pull_request
+on:
+  pull_request: {}
+  push:
+    branches:
+      - main
+      - master
 
 concurrency:
   group: ${{ github.ref_name }}


### PR DESCRIPTION
When merging a passing PR which was not on top of the last commit of the
main branch, we may break CI.  This make sure a CI run is triggered when
the main branch is updated.  As GitHub kindly display the status of the
last commit on a project page, this allow to quickly see if a module CI
works as intended or not.

The main branch of most of our modules is `master` but a few use the
more inclusive `main` name, so enable ci for both.
