### PR TITLE
CI: Allow to run CI manually

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: noop run
 
 on:
+  workflow_dispatch: {}
   pull_request: {}
   push:
     branches:


### PR DESCRIPTION
We have one CI job that prints outdated module dependencies. It makes sense to not only run this on PRs but also manually.