### PR TITLE
CI: Print summary for outdated modules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,20 @@ jobs:
       - name: Run msync --noop
         run: bundle exec msync clone --git-base=https://github.com/
       - run: bundle exec rake metadata_deps
+  outdated_module_summary:
+    runs-on: ubuntu-latest
+    name: Prints a list of all modules with outdated modulesync_config version
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - name: Run msync --noop
+        run: bundle exec msync clone --git-base=https://github.com/
+      - name: Generate summary
+        run: bundle exec bin/outdated_modules_and_their_version
 
   tests:
     needs:

--- a/bin/outdated_modules_and_their_version
+++ b/bin/outdated_modules_and_their_version
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+require 'yaml'
+require 'erb'
+
+# the current version in modulesync_config
+version = YAML.load(ERB.new(File.read('moduleroot/.msync.yml.erb')).result)['modulesync_config_version']
+
+puts "current version: #{version}"
+puts '---------------------------------------------'
+puts "| Module\t| modulesync_config version |"
+puts '---------------------------------------------'
+Dir.glob('modules/voxpupuli/puppet-*/.msync.yml').each do|f|
+  version_module = YAML.load_file(f)['modulesync_config_version']
+  mod = f.split('/')[2]
+  puts "| #{mod}\t| #{version_module}\t|" if version != version_module
+end


### PR DESCRIPTION
Previously we only printed a diff for every module. Now we also print a hacky table with every outdated module.