### PR TITLE
CI: run msync with branch foobranch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           ruby-version: 2.7
           bundler-cache: true
       - name: Run msync --noop
-        run: bundle exec msync update --noop --git-base=https://github.com/
+        run: bundle exec msync update --noop --git-base=https://github.com/ --branch foobranch
   metadata_json_deps:
     runs-on: ubuntu-latest
     name: Run metadata_json_deps on all modules


### PR DESCRIPTION
By default we write into the branch modulesync. That's configured in modulesync.yml. msync will check for an existing branch and then update it, instead of master. That's fine for normal operations, but not for our CI. Our noop run in CI should detect which modulesync_config changes aren't yet merged, so we need to use a different branch here.