### PR TITLE
Addition of puppet-swap_file

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -158,6 +158,7 @@
 - puppet-stackify
 - puppet-stash
 - puppet-strongswan
+- puppet-swap_file
 - puppet-systemd
 - puppet-tang
 - puppet-telegraf


### PR DESCRIPTION
puppet-swap_file is a fork from

https://github.com/petems/petems-swap_file/commit/b1dc3fc0254149aabbbbafd82e83702a2a38092f