### PR TITLE
Allow beaker_hypervisor to be set

### DIFF
--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -29,6 +29,9 @@ jobs:
 <%- if @configs['beaker_facter'] -%>
       beaker_facter: '<%= @configs['beaker_facter'] %>'
 <%- end -%>
+<%- if @configs['beaker_hypervisor'] -%>
+      beaker_hypervisor: '<%= @configs['beaker_hypervisor'] %>'
+<%- end -%>
 <%- if @configs['acceptance_runs_on'] -%>
       acceptance_runs_on: '<%= @configs['acceptance_runs_on'] %>'
 <%- end -%>


### PR DESCRIPTION
Since https://github.com/voxpupuli/gha-puppet/pull/49 it is possible to use vagrant rather than default docker hypervisor.

Allow that configuration to be set via `.sync.yml`

```yaml
---
.github/workflows/ci.yml:
  beaker_hypervisor:  'vagrant_libvirt'
```