### PR TITLE
add puppet-sysctl to module sync

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -159,6 +159,7 @@
 - puppet-stash
 - puppet-strongswan
 - puppet-swap_file
+- puppet-sysctl
 - puppet-systemd
 - puppet-tang
 - puppet-telegraf


### PR DESCRIPTION
I have forked thias-sysctl to voxpupuli. This is a module at least I require to be compatible with puppet8. Since the origin hasn't had any development I decided to fork it.