### PR TITLE
Ensure Dockerfile gets deleted

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -147,5 +147,7 @@ Modulefile:
   delete: true
 Makefile:
   delete: true
+Dockerfile:
+  delete: true
 ...
 # vim: syntax=yaml


### PR DESCRIPTION
It has already been removed from modulesync with #827, but needs to be added as `delete: true` to config_defaults.yml for the actual repository purge.