### PR TITLE
Add missing modules to output

### DIFF
--- a/bin/outdated_modules_and_their_version
+++ b/bin/outdated_modules_and_their_version
@@ -11,13 +11,23 @@ mod_ary = []
 width_modules = 6
 # min width is width of String "modulesync_config version"
 width_version = 25
-Dir.glob('modules/voxpupuli/puppet-*/.msync.yml').each do|f|
-  version_module = YAML.load_file(f)['modulesync_config_version']
-  mod = f.split('/')[2]
-  if version != version_module
-    mod_ary.push([mod, version_module])
-    width_modules = [width_modules, mod.length].max
-    width_version = [width_version, version_module.length].max
+Dir.glob('modules/voxpupuli/puppet-*').each do |f|
+  if File.directory?(f)
+    if File.exists?(f + '/.msync.yml')
+      version_module = YAML.load_file(f + '/.msync.yml')['modulesync_config_version']
+      mod = (f + '/.msync.yml').split('/')[2]
+      if version != version_module
+        mod_ary.push([mod, version_module])
+        width_modules = [width_modules, mod.length].max
+        width_version = [width_version, version_module.length].max
+      end
+    else
+      version_module = 'None'
+      mod = (f + '/.msync.yml').split('/')[2]
+      mod_ary.push([mod, version_module])
+      width_modules = [width_modules, mod.length].max
+      width_version = [width_version, version_module.length].max
+    end
   end
 end
 

--- a/bin/outdated_modules_and_their_version
+++ b/bin/outdated_modules_and_their_version
@@ -11,23 +11,21 @@ mod_ary = []
 width_modules = 6
 # min width is width of String "modulesync_config version"
 width_version = 25
-Dir.glob('modules/voxpupuli/puppet-*').each do |f|
-  if File.directory?(f)
-    if File.exists?(f + '/.msync.yml')
-      version_module = YAML.load_file(f + '/.msync.yml')['modulesync_config_version']
-      mod = (f + '/.msync.yml').split('/')[2]
-      if version != version_module
-        mod_ary.push([mod, version_module])
-        width_modules = [width_modules, mod.length].max
-        width_version = [width_version, version_module.length].max
-      end
-    else
-      version_module = 'None'
-      mod = (f + '/.msync.yml').split('/')[2]
+Dir.glob('modules/voxpupuli/puppet-*').sort.each do |f|
+  if File.exists?(f + '/.msync.yml')
+    version_module = YAML.load_file(f + '/.msync.yml')['modulesync_config_version']
+    mod = (f).split('/')[2]
+    if version != version_module
       mod_ary.push([mod, version_module])
       width_modules = [width_modules, mod.length].max
       width_version = [width_version, version_module.length].max
     end
+  else
+    version_module = 'None'
+    mod = (f).split('/')[2]
+    mod_ary.push([mod, version_module])
+    width_modules = [width_modules, mod.length].max
+    width_version = [width_version, version_module.length].max
   end
 end
 


### PR DESCRIPTION
Adds previously missing modules as not all modules have had a modulesync applied yet and therefore .msync.yml is missing.
Fixes: #872 