### PR TITLE
Delete legacy .pcci.yml

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -149,5 +149,7 @@ Makefile:
   delete: true
 Dockerfile:
   delete: true
+.pcci.yml:
+  delete: true
 ...
 # vim: syntax=yaml


### PR DESCRIPTION
A long long time ago this was used to run acceptance tests. The infrastructure got decomissioned, so we can remove the config files.