### PR TITLE
Support arbitrary inputs to reusable workflow files

### DIFF
--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -23,6 +23,11 @@ jobs:
     uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v2
     with:
       pidfile_workaround: '<%= @configs['pidfile_workaround'] %>'
+<%- if @configs['with'] -%>
+<%- @configs['with'].each do |k,v| -%>
+      <%= k %>: <%=  v %>
+<%- end -%>
+<%- end -%>
 <%- if @configs['unit_runs_on'] -%>
       unit_runs_on: '<%= @configs['unit_runs_on'] %>'
 <%- end -%>
@@ -37,8 +42,13 @@ jobs:
 <%- end -%>
 <%- else -%>
     uses: voxpupuli/gha-puppet/.github/workflows/basic.yml@v2
-<%- if @configs.key?('rubocop') || !@configs['additional_packages'].empty? || @configs.key?('unit_runs_on') -%>
+<%- if @configs.key?('rubocop') || !@configs['additional_packages'].empty? || @configs.key?('unit_runs_on') || @configs.key?('with') -%>
     with:
+<%- end -%>
+<%- if @configs['with'] -%>
+<%- @configs['with'].each do |k,v| -%>
+      <%= k %>: <%=  v %>
+<%- end -%>
 <%- end -%>
 <%- end -%>
 <%- unless @configs['additional_packages'].empty? -%>

--- a/moduleroot/.github/workflows/release.yml.erb
+++ b/moduleroot/.github/workflows/release.yml.erb
@@ -14,6 +14,11 @@ jobs:
     name: Release
     uses: voxpupuli/gha-puppet/.github/workflows/release.yml@v2
     with:
+<%- if @configs['with'] -%>
+<%- @configs['with'].each do |k,v| -%>
+      <%= k %>: <%=  v %>
+<%- end -%>
+<%- end -%>
       allowed_owner: '<%= @configs[:namespace] %>'
     secrets:
       # Configure secrets here:


### PR DESCRIPTION
1. step in #887 

Add possibility to use `with` as a key to `.github/workflows/ci.yml` and `.github/workflows/release.yml` in `.sync.yml`
i.e:
```
.github/workflows/ci.yml:
  with:
    rubocop: false
```
or
```
.github/workflows/release.yml:
  with:
    working-directory: 'my-special-dir'
```
