### PR TITLE
Correct variable name for changelog github token

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,5 +183,5 @@ the `modulesync_config` repository.
 ## Do a new release
 
 * Update the version in `moduleroot/.msync.yml.erb`
-* export `GITHUB_CHANGELOG_TOKEN='*your token*'`
-* bundle exec rake changelog
+* `CHANGELOG_GITHUB_TOKEN='*your token*' bundle exec rake changelog`
+


### PR DESCRIPTION
Following the existing doc led to:
```
Warning: No token provided (-t option) and variable $CHANGELOG_GITHUB_TOKEN was not found. This script can make only 50 requests to GitHub API per hour without a token!
```