### PR TITLE
Dont manage .rspec_parallel anymore

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -16,7 +16,7 @@ Gemfile:
   required:
     ':test':
       - gem: voxpupuli-test
-        version: '~> 7.0'
+        version: '~> 7.2'
       - gem: coveralls
       - gem: simplecov-console
       - gem: puppet_metadata
@@ -148,6 +148,10 @@ Makefile:
 Dockerfile:
   delete: true
 .pcci.yml:
+  delete: true
+.rspec_parallel:
+  delete: true
+.rspec:
   delete: true
 ...
 # vim: syntax=yaml

--- a/moduleroot/.rspec.erb
+++ b/moduleroot/.rspec.erb
@@ -1,5 +1,0 @@
-# Managed by modulesync - DO NOT EDIT
-# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
-
---format documentation
---color

--- a/moduleroot/.rspec_parallel.erb
+++ b/moduleroot/.rspec_parallel.erb
@@ -1,4 +1,0 @@
-# Managed by modulesync - DO NOT EDIT
-# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
-
---format progress


### PR DESCRIPTION
requires https://github.com/puppetlabs/puppetlabs_spec_helper/pull/451 since https://github.com/puppetlabs/puppetlabs_spec_helper/pull/446 the rake task configures the output so we don't need .rspec_parallel anymore.