### PR TITLE
Use lint rake task for lint pre-commit check

### DIFF
--- a/moduleroot/.overcommit.yml.erb
+++ b/moduleroot/.overcommit.yml.erb
@@ -43,10 +43,12 @@ PreCommit:
     enabled: true
     description: 'Runs rubocop on modified files only'
     command: ['bundle', 'exec', 'rubocop']
-  PuppetLint:
+  RakeTarget:
     enabled: true
-    description: 'Runs puppet-lint on modified files only'
-    command: ['bundle', 'exec', 'puppet-lint']
+    description: 'Runs lint on modified files only'
+    targets:
+      - 'lint'
+    command: ['bundle', 'exec', 'rake']
   YamlSyntax:
     enabled: true
   JsonSyntax:


### PR DESCRIPTION
The existing `bundle exec puppet-lint` is prone to erroring with autoload errors that are allowed under our normal structure / lint rules.


```
Runs puppet-lint on modified files only..................[PuppetLint] FAILED
Errors on lines you didn't modify:
/Users/wby/git/puppet-rabbitmq/manifests/init.pp:349:7:ERROR: rabbitmq not in autoload module layout (autoloader_layout)
Warnings on lines you didn't modify:
```

This appears to work from some local testing, and AFAICT still runs only on modified files.