### PR TITLE
spec/spec.opts: ensure the file is absent

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -117,6 +117,8 @@ spec/spec_helper_acceptance.rb:
   unmanaged: true
   configure_beaker:
     modules: ':metadata'
+spec/spec.opts:
+  delete: true
 CONTRIBUTING.md:
   delete: true
 .yardopts:


### PR DESCRIPTION
some of our modules have a legacy spec/spec.opts file:

https://github.com/voxpupuli/puppet-allknowingdns/blob/master/spec/spec.opts

We need to ensure that it's absent, otherwise CI won't pass:

https://github.com/voxpupuli/puppet-allknowingdns/actions/runs/9352662814/job/25741367385?pr=61