### PR TITLE
Support fact stringyfication

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -112,6 +112,7 @@ spec/acceptance/nodesets/ec2/windows-2016-base-x64.yml:
   delete: true
 spec/spec_helper.rb:
   add_mocked_facts: true
+  facterdb_string_keys: false
   mock_with: false
 spec/spec_helper_acceptance.rb:
   unmanaged: true

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -8,9 +8,9 @@
 ENV['COVERAGE'] ||= 'yes' if Dir.exist?(File.expand_path('../lib', __dir__))
 
 require 'voxpupuli/test/spec_helper'
-<%- if @configs['hiera_config'] || @configs['mock_with'] -%>
 
 RSpec.configure do |c|
+  c.facterdb_string_keys = <%= @configs['facterdb_string_keys'] %>
 <%- if @configs['hiera_config'] -%>
   c.hiera_config = <%= @configs['hiera_config'] %>
 <%- end -%>
@@ -18,7 +18,6 @@ RSpec.configure do |c|
   c.mock_with <%= @configs['mock_with'] %>
 <%- end -%>
 end
-<%- end -%>
 <%- if @configs['add_mocked_facts'] -%>
 
 add_mocked_facts!


### PR DESCRIPTION
FacterDB/rspec-puppet-facts have an option switch the symbolized first-level keys in a factset to strings (all following/nested keys are always strings). This PR makes this configuration opt-in so we can switch over modules from symbols to strings in their spec files.