### PR TITLE
spec_helper.rb: add missing `=`

### DIFF
--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -15,7 +15,7 @@ RSpec.configure do |c|
   c.hiera_config = <%= @configs['hiera_config'] %>
 <%- end -%>
 <%- if @configs['mock_with'] -%>
-  c.mock_with <%= @configs['mock_with'] %>
+  c.mock_with = <%= @configs['mock_with'] %>
 <%- end -%>
 end
 <%- end -%>


### PR DESCRIPTION
typo from https://github.com/voxpupuli/modulesync_config/pull/909