### PR TITLE
spec_helper.rb: Fix typo in template

### DIFF
--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -15,7 +15,7 @@ RSpec.configure do |c|
   c.hiera_config = <%= @configs['hiera_config'] %>
 <%- end -%>
 <%- if @configs['mock_with'] -%>
-  c.mock_with = <%= @configs['mock_with'] %>
+  c.mock_with <%= @configs['mock_with'] %>
 <%- end -%>
 end
 <%- if @configs['add_mocked_facts'] -%>


### PR DESCRIPTION
previously we had `c.mock_with = <%= @configs['mock_with'] %>`. That's a regression. It's supposed to be `c.mock_with=<%= @configs['mock_with'] %>`. The issue here is the assumption that puppetlabs_spec_helper provides `mock_with` as rspec config option. But that's not the case.

Regression was introduced in 9b09c959db3afe1d92552c3edc95efbfcfec3ad0