### PR TITLE
Purge devcontainer configs

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -156,5 +156,9 @@ Dockerfile:
   delete: true
 .rspec:
   delete: true
+.devcontainer/Dockerfile:
+  delete: true
+.devcontainer/devcontainer.json:
+  delete: true
 ...
 # vim: syntax=yaml


### PR DESCRIPTION
Those files are typically created by pdk and devcontainers cost us money on GitHub.