### PR TITLE
Ignore yamllint warning about truthy value "on"

### DIFF
--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -4,6 +4,7 @@
 
 name: CI
 
+# yamllint disable-line rule:truthy
 on:
   pull_request: {}
   push:

--- a/moduleroot/.github/workflows/labeler.yml.erb
+++ b/moduleroot/.github/workflows/labeler.yml.erb
@@ -4,6 +4,7 @@
 
 name: "Pull Request Labeler"
 
+# yamllint disable-line rule:truthy
 on:
   pull_request_target: {}
 

--- a/moduleroot/.github/workflows/release.yml.erb
+++ b/moduleroot/.github/workflows/release.yml.erb
@@ -4,6 +4,7 @@
 
 name: Release
 
+# yamllint disable-line rule:truthy
 on:
   push:
     tags:


### PR DESCRIPTION
GitHub actions expects "on" as a key, even though in YAML, "on" is a special / truthy value. It's safe to ignore this since GitHub Actions parses it correctly.

Add an explicit ignore for the next line only
Alternate approach to #838

This might be less "technically" correct, but could be another way to go.