### PR TITLE
puppet-catalog-diff: the module was renamed

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -28,10 +28,10 @@
 - puppet-bolt
 - puppet-borg
 - puppet-boundary
+- puppet-ca_cert
 - puppet-caddy
 - puppet-cassandra
-- puppet-catalog-diff
-- puppet-ca_cert
+- puppet-catalog_diff
 - puppet-check_mk
 - puppet-chrony
 - puppet-clevis


### PR DESCRIPTION
The module got renamed from puppet-catalog-diff to puppet-catalog_diff