### PR TITLE
Delete .vscode/extensions.json

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -162,5 +162,7 @@ Dockerfile:
   delete: true
 .devcontainer/README.md:
   delete: true
+.vscode/extensions.json:
+  delete: true
 ...
 # vim: syntax=yaml


### PR DESCRIPTION
This usually comes from PDK-based modules.