### PR TITLE
Cleanup release action

### DIFF
--- a/moduleroot/.github/workflows/release.yml.erb
+++ b/moduleroot/.github/workflows/release.yml.erb
@@ -32,10 +32,3 @@ jobs:
       #  https://docs.github.com/en/actions/security-guides/encrypted-secrets
       username: ${{ secrets.PUPPET_FORGE_USERNAME }}
       api_key: ${{ secrets.PUPPET_FORGE_API_KEY }}
-
-  create-github-release:
-    name: Create GitHub Release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create GitHub release
-        uses: voxpupuli/gha-create-a-github-release@v1


### PR DESCRIPTION
our gha-puppet/release action now creates the github release and attaches the puppet module. We don't need a dedicated job anymore. https://github.com/voxpupuli/gha-puppet/pull/68