### PR TITLE
Add release prep action

### DIFF
--- a/moduleroot/.github/workflows/prepare_release.yml.erb
+++ b/moduleroot/.github/workflows/prepare_release.yml.erb
@@ -1,0 +1,25 @@
+---
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
+name: 'Prepare Release'
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Module version to be released. Must be a valid semver string without leading v. (1.2.3)'
+        required: false
+
+jobs:
+  release_prep:
+    uses: 'voxpupuli/gha-puppet/.github/workflows/prepare_release.yml@v3'
+    with:
+      version: ${{ github.event.inputs.version }}
+<%- unless @configs['with']&.has_key?('allowed_owner') -%>
+      allowed_owner: '<%= @configs[:namespace] %>'
+<%- end -%>
+    secrets:
+      # Configure secrets here:
+      #  https://docs.github.com/en/actions/security-guides/encrypted-secrets
+      github_pat: '${{ secrets.PCCI_PAT_RELEASE_PREP }}'


### PR DESCRIPTION
* This requires https://github.com/voxpupuli/gha-puppet/pull/66
* tested in https://github.com/voxpupuli/puppet-example/pull/97
* this takes a version as input and will bump metadata.json, CHANGELOG.md and create a release PR