### PR TITLE
Automatically label modulesync PRs accordingly

### DIFF
--- a/moduleroot/.github/labeler.yml.erb
+++ b/moduleroot/.github/labeler.yml.erb
@@ -2,5 +2,7 @@
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
+modulesync:
+ - head-branch: ['modulesync']
 skip-changelog:
  - head-branch: ['^release-*', 'release']


### PR DESCRIPTION
When using modulesync, we regularly end-up creating many pull-requests
to merge a `modulesync` branch into main / master.

We have a `modulesync` label that allows such PRs to be excluded from
the ChangeLog… but forgetting to label them when we create them in batch
mean we have to label them one by one by hand which is a PITA.

Adjust the labeller configuration so that PRs against a branch named
`modulesync` is automatically tagged `modulesync`.
