### PR TITLE
Add puppet-usbguard to the list of managed modules

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -180,6 +180,7 @@
 - puppet-tuned
 - puppet-unattended_upgrades
 - puppet-unbound
+- puppet-usbguard
 - puppet-varnish
 - puppet-vault
 - puppet-vault_lookup


### PR DESCRIPTION
Migration to Vox Pupuli: https://github.com/kenyon/puppet-usbguard/issues/1
