### PR TITLE
Drop puppetlabs spec helper mention

### DIFF
--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -7,19 +7,16 @@ rescue LoadError
   # only available if gem group test is installed
 end
 
-# load optional tasks for acceptance
-# only available if gem group releases is installed
 begin
   require 'voxpupuli/acceptance/rake'
 rescue LoadError
+  # only available if gem group acceptance is installed
 end
 
-# load optional tasks for releases
-# only available if gem group releases is installed
 begin
   require 'voxpupuli/release/rake_tasks'
 rescue LoadError
-  # voxpupuli-release not present
+  # only available if gem group releases is installed
 else
   GCGConfig.user = '<%= @configs['config.user'] || @configs[:namespace] %>'
   GCGConfig.project = '<%= @configs['config.project'] || @configs[:puppet_module] %>'

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -1,15 +1,10 @@
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
-# Attempt to load voxpupuli-test (which pulls in puppetlabs_spec_helper),
-# otherwise attempt to load it directly.
 begin
   require 'voxpupuli/test/rake'
 rescue LoadError
-  begin
-    require 'puppetlabs_spec_helper/rake_tasks'
-  rescue LoadError
-  end
+  # only available if gem group test is installed
 end
 
 # load optional tasks for acceptance


### PR DESCRIPTION
Since voxpupuli-test it no longer uses puppetlabs_spec_helper. Also shortens the comments a bit more to please RuboCop while also being more consistent.

Fixes: e326bebe6655 ("voxpupuli-test: Update 9.x -> 10.x")