### PR TITLE
voxpupuli-acceptance: Require 4.x

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -25,7 +25,7 @@ Gemfile:
         version: '>= 0.39.1'
     ':system_tests':
       - gem: voxpupuli-acceptance
-        version: '~> 3.5'
+        version: '~> 4.0'
     ':release':
       - gem: voxpupuli-release
         version: '~> 4.0'


### PR DESCRIPTION
This pulls in a new beaker major release, which requires Ruby 3.2.