### PR TITLE
Purge .github/CONTRIBUTING.md in modules

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -120,6 +120,8 @@ spec/spec.opts:
   delete: true
 CONTRIBUTING.md:
   delete: true
+.github/CONTRIBUTING.md:
+  delete: true
 .yardopts:
   delete: true
 .gitlab-ci.yml:


### PR DESCRIPTION
We already purge `CONTRIBUTING.md`.
The file can also be at `.github/CONTRIBUTING.md`. Both files should be absent because we manage the file at org level at https://github.com/voxpupuli/.github/blob/master/CONTRIBUTING.md