### PR TITLE
Purge PDK leftovers in modules

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -7,6 +7,15 @@
 # PDK creates this
 .github/workflows/puppet-lint.yml:
   delete: true
+# Perforce used those
+.github/workflows/release_without.yml:
+  delete: true
+.github/workflows/release_prep.yml:
+  delete: true
+.github/workflows/nightly.yml:
+  delete: true
+.github/workflows/mend.yml:
+  delete: true
 .travis.yml:
   delete: true
 Jenkinsfile:


### PR DESCRIPTION
Depending on the PDK version, some modules have additional CI configs that we need to purge.