### PR TITLE
CI: Optimize release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,8 @@ jobs:
     name: Create GitHub release
     if: ${{ github.repository_owner == 'voxpupuli' }}
     steps:
-      - name: checkout code
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
       - name: Create Release Page
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create ${{ github.ref_name }} --generate-notes
+        run: gh release create --repo ${{ github.repository }} ${{ github.ref_name }} --generate-notes


### PR DESCRIPTION
When we provide the repo name to the `gh` CLI, we don't need to checkout the code. We do this already at https://github.com/voxpupuli/gem-workflow-test/blob/master/.github/workflows/release.yml#L49