### PR TITLE
Add allowed_owner setting to avoid changes on fork

### DIFF
--- a/moduleroot/.github/workflows/prepare_release.yml.erb
+++ b/moduleroot/.github/workflows/prepare_release.yml.erb
@@ -21,7 +21,7 @@ jobs:
     with:
       version: ${{ github.event.inputs.version }}
 <%- unless @configs['with']&.has_key?('allowed_owner') -%>
-      allowed_owner: '<%= @configs[:namespace] %>'
+      allowed_owner: '<%= @configs['allowed_owner'] || @configs[:namespace] %>'
 <%- end -%>
     secrets:
       # Configure secrets here:

--- a/moduleroot/.github/workflows/release.yml.erb
+++ b/moduleroot/.github/workflows/release.yml.erb
@@ -28,7 +28,7 @@ jobs:
 <%- end -%>
 <%- end -%>
 <%- unless @configs['with']&.has_key?('allowed_owner') -%>
-      allowed_owner: '<%= @configs[:namespace] %>'
+      allowed_owner: '<%= @configs['allowed_owner'] || @configs[:namespace] %>'
 <%- end -%>
     secrets:
       # Configure secrets here:


### PR DESCRIPTION
This allows people to use modulesync_config to run msync update on forked projects without changing GitHub related things.

Example of current behaviour:
<img width="1348" height="1056" alt="image" src="https://github.com/user-attachments/assets/dbf3151a-0efe-45a8-918a-a42b4ca7206b" />

Example of new behaviour:
<img width="1329" height="481" alt="image" src="https://github.com/user-attachments/assets/e6e4b060-7228-405b-a2cc-86782ac6bb4b" />
