### PR TITLE
Don't delete `.devcontainer/devcontainer.json`

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -169,8 +169,6 @@ Dockerfile:
   delete: true
 .devcontainer/Dockerfile:
   delete: true
-.devcontainer/devcontainer.json:
-  delete: true
 .devcontainer/README.md:
   delete: true
 .vscode/extensions.json:


### PR DESCRIPTION
Since this file was added in #976, we shouldn't also be deleting it.