### PR TITLE
Add puppet-windows_power

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -194,6 +194,7 @@
 - puppet-virtualbox
 - puppet-wildfly
 - puppet-windows_firewall
+- puppet-windows_power
 - puppet-windowsfeature
 - puppet-winlogbeat
 - puppet-wireguard


### PR DESCRIPTION
this module has been removed some years ago and with restarting maintenance everyone forgot to re-add it again.